### PR TITLE
add note for lighthouse and geth

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,10 @@ With the DKG ceremony over, the last phase before activation is to prepare your 
 
 Before completing these instructions, you should assign a static local IP address to your device (extending the DHCP reservation indefinitely or removing the device from the DCHP pool entirely if you prefer), and port forward the TCP protocol on the public port `:3610` on your router to your device's local IP address on the same port. This step is different for every person's home internet, and can be complicated by the presence of dynamic public IP addresses. We are currently working on making this as easy as possible, but for the time being, a distributed validator cluster isn't going to work very resiliently if all charon nodes cannot talk directly to one another and instead need to have an intermediary node forwarding traffic to them. 
 
+**Caution**: If you manually update `docker-compose` to mount `lighthouse` from your locally synced `~/.lighthouse`, the whole chain database may get deleted. It'd be best not to manually update as `lighthouse` checkpoint-syncs so the syncing doesn't take much time.
+
+**NOTE**: If you have a `geth` node already synced, you can simply copy over the directory. For ex: `cp -r ~/.ethereum/goerli data/geth`. This makes everything faster since you start from a synced geth node.
+
 ```
 # Delete lighthouse data if it exists
 rm -r ./data/lighthouse


### PR DESCRIPTION
- Add caution for mounting lighthouse from locally synced LH BN.
- Add note for copying an already synced geth node which makes things faster.