### PR TITLE
Improve failed duty panel

### DIFF
--- a/grafana/dashboards/single_node_dashboard.json
+++ b/grafana/dashboards/single_node_dashboard.json
@@ -1060,7 +1060,7 @@
         "defaults": {
           "color": {
             "fixedColor": "dark-yellow",
-            "mode": "fixed"
+            "mode": "thresholds"
           },
           "mappings": [],
           "thresholds": {
@@ -1071,8 +1071,12 @@
                 "value": null
               },
               {
+                "color": "blue",
+                "value": 0
+              },
+              {
                 "color": "green",
-                "value": ""
+                "value": 1
               }
             ]
           }
@@ -1197,16 +1201,18 @@
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
       },
+      "description": "Counters of each duty failed  by this cluster, separated by duty type",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "",
+            "axisLabel": "Duties",
             "axisPlacement": "auto",
+            "axisSoftMin": 0,
             "barAlignment": 0,
-            "drawStyle": "line",
+            "drawStyle": "bars",
             "fillOpacity": 0,
             "gradientMode": "none",
             "hideFrom": {
@@ -1274,7 +1280,7 @@
           },
           "editorMode": "code",
           "exemplar": false,
-          "expr": "validator_duties_performed{result=\"failed\"}",
+          "expr": "increase(validator_duties_performed{result=\"failed\"}[$__rate_interval])",
           "format": "time_series",
           "instant": false,
           "interval": "",
@@ -1296,7 +1302,7 @@
     "list": []
   },
   "time": {
-    "from": "now-5m",
+    "from": "now-1h",
     "to": "now"
   },
   "timepicker": {
@@ -1316,6 +1322,6 @@
   "timezone": "",
   "title": "Single Charon Node Dashboard",
   "uid": "singlenode",
-  "version": 1,
+  "version": 2,
   "weekStart": ""
 }


### PR DESCRIPTION
﻿Currently the failed tracker grows indefinitely for failed attestations. Wrapping the command in `increase()[interval]` makes it more easy to see what's going wrong.
<img width="557" alt="Screenshot 2022-08-06 at 17 11 54" src="https://user-images.githubusercontent.com/4981644/183257165-dad8ef2e-59b8-482e-83e2-28e05d886c31.png">
 