### PR TITLE
Add NAT panel to dashboard

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,7 +73,7 @@ services:
   charon:
     # Pegged charon version (update this for each release).
     # image: obolnetwork/charon:${CHARON_VERSION}
-    image: ghcr.io/obolnetwork/charon:4453fee
+    image: ghcr.io/obolnetwork/charon:d8eca51
     depends_on:
       - lighthouse
     environment:

--- a/grafana/dashboards/single_node_dashboard.json
+++ b/grafana/dashboards/single_node_dashboard.json
@@ -89,7 +89,7 @@
         },
         "textMode": "none"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -152,7 +152,7 @@
         },
         "showHeader": false
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -238,7 +238,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -298,7 +298,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -373,7 +373,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "expr": "core_scheduler_current_slot",
@@ -456,7 +456,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -530,7 +530,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -934,7 +934,7 @@
         },
         "textMode": "none"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -1016,7 +1016,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {
@@ -1093,7 +1093,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "expr": "validator_current_epoch",
@@ -1154,7 +1154,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "expr": "validator_beacon_node_published_attestation_total",
@@ -1219,7 +1219,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "expr": "validator_beacon_node_published_block_total",
@@ -1284,7 +1284,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "8.5.3",
+      "pluginVersion": "9.0.2",
       "targets": [
         {
           "datasource": {

--- a/grafana/dashboards/single_node_dashboard.json
+++ b/grafana/dashboards/single_node_dashboard.json
@@ -29,6 +29,19 @@
   "liveNow": false,
   "panels": [
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 48,
+      "panels": [],
+      "title": "Charon",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
@@ -59,9 +72,9 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 0
+        "y": 1
       },
-      "id": 38,
+      "id": 53,
       "options": {
         "colorMode": "none",
         "graphMode": "none",
@@ -76,7 +89,7 @@
         },
         "textMode": "none"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -126,7 +139,7 @@
         "h": 4,
         "w": 6,
         "x": 0,
-        "y": 1
+        "y": 2
       },
       "id": 32,
       "options": {
@@ -139,7 +152,7 @@
         },
         "showHeader": false
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -208,7 +221,7 @@
         "h": 4,
         "w": 4,
         "x": 6,
-        "y": 1
+        "y": 2
       },
       "id": 42,
       "options": {
@@ -225,7 +238,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -268,7 +281,7 @@
         "h": 4,
         "w": 3,
         "x": 10,
-        "y": 1
+        "y": 2
       },
       "id": 6,
       "options": {
@@ -285,7 +298,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -342,7 +355,7 @@
         "h": 4,
         "w": 4,
         "x": 13,
-        "y": 1
+        "y": 2
       },
       "id": 4,
       "links": [],
@@ -360,7 +373,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "expr": "core_scheduler_current_slot",
@@ -426,7 +439,7 @@
         "h": 4,
         "w": 3,
         "x": 17,
-        "y": 1
+        "y": 2
       },
       "id": 46,
       "options": {
@@ -443,7 +456,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -500,7 +513,7 @@
         "h": 4,
         "w": 4,
         "x": 20,
-        "y": 1
+        "y": 2
       },
       "id": 34,
       "options": {
@@ -517,7 +530,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -593,7 +606,7 @@
         "h": 9,
         "w": 8,
         "x": 0,
-        "y": 5
+        "y": 6
       },
       "id": 2,
       "options": {
@@ -687,7 +700,7 @@
         "h": 9,
         "w": 9,
         "x": 8,
-        "y": 5
+        "y": 6
       },
       "id": 40,
       "options": {
@@ -826,7 +839,7 @@
         "h": 9,
         "w": 7,
         "x": 17,
-        "y": 5
+        "y": 6
       },
       "id": 13,
       "maxDataPoints": 1296,
@@ -861,6 +874,19 @@
       "type": "timeseries"
     },
     {
+      "collapsed": false,
+      "gridPos": {
+        "h": 1,
+        "w": 24,
+        "x": 0,
+        "y": 15
+      },
+      "id": 50,
+      "panels": [],
+      "title": "Validator",
+      "type": "row"
+    },
+    {
       "datasource": {
         "type": "prometheus",
         "uid": "PBFA97CFB590B2093"
@@ -891,7 +917,7 @@
         "h": 1,
         "w": 24,
         "x": 0,
-        "y": 14
+        "y": 16
       },
       "id": 36,
       "options": {
@@ -908,7 +934,7 @@
         },
         "textMode": "none"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -971,7 +997,7 @@
         "h": 4,
         "w": 4,
         "x": 0,
-        "y": 15
+        "y": 17
       },
       "id": 25,
       "links": [],
@@ -990,7 +1016,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -1048,7 +1074,7 @@
         "h": 4,
         "w": 4,
         "x": 4,
-        "y": 15
+        "y": 17
       },
       "id": 23,
       "links": [],
@@ -1067,7 +1093,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "expr": "validator_current_epoch",
@@ -1111,7 +1137,7 @@
         "h": 4,
         "w": 4,
         "x": 8,
-        "y": 15
+        "y": 17
       },
       "id": 29,
       "options": {
@@ -1128,7 +1154,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "expr": "validator_beacon_node_published_attestation_total",
@@ -1176,7 +1202,7 @@
         "h": 4,
         "w": 4,
         "x": 12,
-        "y": 15
+        "y": 17
       },
       "id": 30,
       "options": {
@@ -1193,7 +1219,7 @@
         },
         "textMode": "auto"
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "expr": "validator_beacon_node_published_block_total",
@@ -1244,7 +1270,7 @@
         "h": 4,
         "w": 8,
         "x": 16,
-        "y": 15
+        "y": 17
       },
       "id": 21,
       "options": {
@@ -1258,7 +1284,7 @@
         "showHeader": false,
         "sortBy": []
       },
-      "pluginVersion": "9.0.2",
+      "pluginVersion": "8.5.3",
       "targets": [
         {
           "datasource": {
@@ -1346,7 +1372,7 @@
         "h": 8,
         "w": 8,
         "x": 0,
-        "y": 19
+        "y": 21
       },
       "id": 27,
       "options": {
@@ -1411,6 +1437,6 @@
   "timezone": "",
   "title": "Single Charon Node Dashboard",
   "uid": "singlenode",
-  "version": 1,
+  "version": 7,
   "weekStart": ""
 }

--- a/grafana/dashboards/single_node_dashboard.json
+++ b/grafana/dashboards/single_node_dashboard.json
@@ -266,7 +266,7 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 4,
+        "w": 3,
         "x": 10,
         "y": 1
       },
@@ -340,8 +340,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 14,
+        "w": 4,
+        "x": 13,
         "y": 1
       },
       "id": 4,
@@ -370,6 +370,95 @@
         }
       ],
       "title": "Latest Slot",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "description": "Current libp2p reachability status of this node as detected by AutoNat.",
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [
+            {
+              "options": {
+                "0": {
+                  "color": "yellow",
+                  "index": 1,
+                  "text": "Unknown"
+                },
+                "1": {
+                  "color": "green",
+                  "index": 0,
+                  "text": "Public"
+                },
+                "2": {
+                  "color": "orange",
+                  "index": 2,
+                  "text": "Private"
+                }
+              },
+              "type": "value"
+            }
+          ],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          },
+          "unit": "none"
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 3,
+        "x": 17,
+        "y": 1
+      },
+      "id": 46,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.0.2",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "exemplar": true,
+          "expr": "p2p_reachability_status{job=\"$node\"}",
+          "hide": false,
+          "interval": "",
+          "legendFormat": "",
+          "refId": "A"
+        }
+      ],
+      "title": "P2P Reachability",
       "type": "stat"
     },
     {
@@ -409,8 +498,8 @@
       },
       "gridPos": {
         "h": 4,
-        "w": 5,
-        "x": 19,
+        "w": 4,
+        "x": 20,
         "y": 1
       },
       "id": 34,
@@ -1322,6 +1411,6 @@
   "timezone": "",
   "title": "Single Charon Node Dashboard",
   "uid": "singlenode",
-  "version": 2,
+  "version": 1,
   "weekStart": ""
 }


### PR DESCRIPTION
Corver added a new feature to test your nodes autonat ability. This adds the same panel to the public dashboard,  such that we can gradually gather some data points as people post screenshots of their dashboard. Also breaks the dashboard into rows. My hope is this starts showing data when there are multiple nodes in this cluster speaking this new version? 

<img width="1680" alt="Screenshot 2022-08-09 at 00 39 56" src="https://user-images.githubusercontent.com/4981644/183532666-269b9a1f-b008-4e9f-a987-156298493fb5.png">
 