### PR TITLE
add docker compose for charon bootnode

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,21 @@ scrape_configs:
 
 Thanks for trying our quickstart guide!
 
+## Steps to host your own bootnode
+
+```
+# Clone the repo and cd into it.
+git clone https://github.com/ObolNetwork/charon-distributed-validator-node.git
+
+cd charon-distributed-validator-node/bootnode
+
+# Replace "1.2.3.4" with the public IPv4 address of your hosted bootnode by editing docker-compose.yml file. (Line 32-33)
+nano docker-compose.yml
+
+# Save and file and you are good to go!
+docker-compose up
+```
+
 # Project Status
 
 It is still early days for the Obol Network and everything is under active development.

--- a/README.md
+++ b/README.md
@@ -162,16 +162,16 @@ Thanks for trying our quickstart guide!
 
 ## Steps to host your own bootnode
 
+You can also host your own bootnode on a separate server.
 ```
 # Clone the repo and cd into it.
 git clone https://github.com/ObolNetwork/charon-distributed-validator-node.git
 
 cd charon-distributed-validator-node/bootnode
 
-# Replace "1.2.3.4" with the public IPv4 address of your hosted bootnode by editing docker-compose.yml file. (Line 32-33)
+# Replace "1.2.3.4" with the public IPv4 address of your hosted bootnode by editing docker-compose.yml file. (Line 32 and 33)
 nano docker-compose.yml
 
-# Save and file and you are good to go!
 docker-compose up
 ```
 

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   bootnode:
     # Pegged charon version (update this for each release).
     # image: obolnetwork/charon:${CHARON_VERSION}
-    image: ghcr.io/obolnetwork/charon:d8eca51
+    image: ghcr.io/obolnetwork/charon:b40678b
     environment:
       CHARON_JAEGER_ADDRESS: jaeger:6831
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -9,7 +9,7 @@ services:
   bootnode:
     # Pegged charon version (update this for each release).
     # image: obolnetwork/charon:${CHARON_VERSION}
-    image: ghcr.io/obolnetwork/charon:b40678b
+    image: ghcr.io/obolnetwork/charon:14ce3bf
     environment:
       CHARON_JAEGER_ADDRESS: jaeger:6831
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -15,7 +15,7 @@ services:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_LOG_LEVEL: debug
-      CHARON_P2P_RELAY_LOGLEVEL: debug
+      CHARON_P2P_RELAY_LOGLEVEL: info
       CHARON_BOOTNODE_HTTP_ADDRESS: "0.0.0.0:3640"
       CHARON_P2P_BOOTNODES: ""
       CHARON_P2P_EXTERNAL_HOSTNAME: bootnode
@@ -25,10 +25,12 @@ services:
       - 3610:3610/tcp
       - 3620:3620/tcp
       - 3630:3630/udp
+      - 3640:3640/tcp
+    # Replace "1.2.3.4" with your own Public IPv4 for both p2p-external-ip and p2p-external-hostname.
     command: |
       bootnode
-      --p2p-external-ip="34.91.187.129"
-      --p2p-external-hostname="34.91.187.129"
+      --p2p-external-ip="1.2.3.4"
+      --p2p-external-hostname="1.2.3.4"
     networks: [bootnode]
     volumes:
       - .charon:/opt/charon/.charon

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -1,0 +1,37 @@
+version: "3.8"
+
+services:
+  #  _                 _                   _
+  # | |__   ___   ___ | |_ _ __   ___   __| | ___
+  # | '_ \ / _ \ / _ \| __| '_ \ / _ \ / _` |/ _ \
+  # | |_) | (_) | (_) | |_| | | | (_) | (_| |  __/
+  # |_.__/ \___/ \___/ \__|_| |_|\___/ \__,_|\___|
+  bootnode:
+    # Pegged charon version (update this for each release).
+    # image: obolnetwork/charon:${CHARON_VERSION}
+    image: ghcr.io/obolnetwork/charon:d8eca51
+    environment:
+      CHARON_JAEGER_ADDRESS: jaeger:6831
+      CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
+      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
+      CHARON_LOG_LEVEL: debug
+      CHARON_P2P_RELAY_LOGLEVEL: debug
+      CHARON_BOOTNODE_HTTP_ADDRESS: "0.0.0.0:3640"
+      CHARON_P2P_BOOTNODES: ""
+      CHARON_P2P_EXTERNAL_HOSTNAME: bootnode
+      CHARON_JAEGER_SERVICE: charon
+    ports:
+      - 3600:3600/tcp
+      - 3610:3610/tcp
+      - 3620:3620/tcp
+      - 3630:3630/udp
+    command: |
+      bootnode
+      --p2p-external-ip="34.91.187.129"
+      --p2p-external-hostname="34.91.187.129"
+    networks: [bootnode]
+    volumes:
+      - .charon:/opt/charon/.charon
+    restart: on-failure
+networks:
+  bootnode:


### PR DESCRIPTION
- Adds a `docker-compose.yaml` file for running charon bootnodes on your own