### PR TITLE
bootnode: fix missing private key folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,8 @@ Configure **ALL** charon nodes in your cluster to use this bootnode:
 - Either by adding a flag: `--p2p-bootnodes=http://replace.with.public.ip.or.hostname:3640/enr`
 - Or by setting the environment variable: `CHARON_P2P_BOOTNODES=http://replace.with.public.ip.or.hostname:3640/enr`
 
+Note that a local `.charon/charon-enr-private-key` file will be created next to `bootnode/docker-compose.yml` to ensure a persisted bootnode ENR across restarts. 
+
 # Project Status
 
 It is still early days for the Obol Network and everything is under active development.

--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ git clone https://github.com/ObolNetwork/charon-distributed-validator-node.git
 
 cd charon-distributed-validator-node/bootnode
 
-# Replace 'replace.with.public.ip.or.hostname' in docker-compose.yml with your public IPv4 or DNS hostname
+# Replace 'replace.with.public.ip.or.hostname' in docker-compose.yml with your public IPv4 or DNS hostname (exclude prefix 'http(s)://')
 nano docker-compose.yml
 
 docker-compose up

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_BOOTNODE_HTTP_ADDRESS: 0.0.0.0:3640
       CHARON_LOG_LEVEL: debug
-      CHARON_P2P_EXTERNAL_HOST: replace.with.public.ip.or.hostname
+      CHARON_P2P_EXTERNAL_HOSTNAME: replace.with.public.ip.or.hostname
     ports:
       - 3610:3610/tcp
       - 3630:3630/udp

--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -20,4 +20,6 @@ services:
       - 3630:3630/udp
       - 3640:3640/tcp
     command: bootnode
+    volumes:
+      - .charon:/opt/charon/.charon # Bootnode charon-enr-private-key generated and persisted across restarts in this folder
     restart: on-failure


### PR DESCRIPTION
Fixes bootnodes missing `.charon` volume removed during previous cleanup.