### PR TITLE
Keep lighthouse data persistent between restarts.

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,10 +55,10 @@ services:
     command: |
       lighthouse bn
       --network=goerli
-      --purge-db
       --checkpoint-sync-url=https://goerli.checkpoint-sync.ethdevops.io
       --execution-endpoint=http://geth:8551
       --execution-jwt=/opt/jwt/jwt.hex
+      --datadir=/opt/app/beacon/
       --http
       --http-address=0.0.0.0
       --http-port=5052


### PR DESCRIPTION
Thank you for your great work! I’m very excited to be a part of this project! With the current setup, the lighthouse is not saving its data into a docker volume. That data is discarded during the restart or shutdown of the lighthouse container. And because of this, the lighthouse downloads the whole database after each restart. That creates unnecessary load on the local disc subsystem (high I/O and excessive wear of the SSD) and it generates additional traffic on the network. Also, this behaviour is causing the filesystem to grow in the docker root directory and not in ./data/lighthouse as you may expect.