### PR TITLE
Refactor env file and default config

### DIFF
--- a/.env.create_dkg.sample
+++ b/.env.create_dkg.sample
@@ -1,0 +1,24 @@
+# Cluster definition config required by `charon create dkg` command which generates the cluster-definition.json file.
+
+# NOTE: These environment variables are used as part the README.md's step 2 `Leader creates the
+#       DKG configuration file and distributes it to everyone else`.
+# NOTE: You cannot declare or use variables (like ${FOO}) as the current file is an environment
+#       file itself not a script.
+
+# Define the charon cluster name. Wrap in `"` when including spaces.
+# E.g., CHARON_NAME="My Obol DVT Cluster"
+CHARON_NAME=
+
+# Define the cluster operator ENRs as a comma seperated list. Do not include any spaces. Include the `enr://` prefix.
+# E.g., CHARON_OPERATOR_ENRS=enr://abcdef,enr://123456,enr://987654
+CHARON_OPERATOR_ENRS=
+
+# Define the cluster Ethereum fee recipient address.
+# E.g., CHARON_FEE_RECIPIENT_ADDRESS=0x000000000000000000000000000000000000dead
+CHARON_FEE_RECIPIENT_ADDRESS=
+
+# Define the cluster Ethereum withdrawal address.
+# E.g., CHARON_WITHDRAWAL_ADDRESS=0x000000000000000000000000000000000000dead
+CHARON_WITHDRAWAL_ADDRESS=
+
+

--- a/.env.create_dkg.sample
+++ b/.env.create_dkg.sample
@@ -9,7 +9,7 @@
 # E.g., CHARON_NAME="My Obol DVT Cluster"
 CHARON_NAME=
 
-# Define the cluster operator ENRs as a comma seperated list. Do not include any spaces. Include the `enr://` prefix.
+# Define the cluster operator ENRs as a comma separated list. Do not include any spaces. Include the `enr://` prefix.
 # E.g., CHARON_OPERATOR_ENRS=enr://abcdef,enr://123456,enr://987654
 CHARON_OPERATOR_ENRS=
 

--- a/.env.sample
+++ b/.env.sample
@@ -15,7 +15,7 @@
 
 ######### Lighthouse Config #########
 
-# Lighthouse beacon node docker container image version, e.g. `latest` or `v2.0.1`.
+# Lighthouse beacon node docker container image version, e.g. `latest` or `v3.0.0`.
 # See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
 #LIGHTHOUSE_VERSION=
 

--- a/.env.sample
+++ b/.env.sample
@@ -38,10 +38,10 @@
 # See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
 #CHARON_VERSION=
 
-# Define custom bootnodes. One or more ENRs or an http URL that return an ENR. Use a comma seperated list excluding spaces.
+# Define custom bootnodes. One or more ENRs or an http URL that return an ENR. Use a comma separated list excluding spaces.
 #CHARON_P2P_BOOTNODES=
 
-# Connect to one or more external beacon nodes. Use a comma seperated list excluding spaces.
+# Connect to one or more external beacon nodes. Use a comma separated list excluding spaces.
 #CHARON_BEACON_NODE_ENDPOINTS=
 
 # Override the charon logging level; debug, info, warning, error.

--- a/.env.sample
+++ b/.env.sample
@@ -1,18 +1,68 @@
-# Replace the ENR variables below with participant ENRs to create cluster-definition.json for create dkg command.
-# Separate the ENRs with a comma not followed by a space and include the `enr:-` prefix
-# NOTE: You cannot declare and use variables (like $ENR1) as the current file is an environment file not a script.
-CHARON_OPERATOR_ENRS=ENR1,ENR2,ENR3,ENR4
+# This is a sample environment file that allows overriding default configuration defined
+# in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
-# Charon
-CHARON_VERSION=d3ae2c2
-CHARON_BEACON_NODE_ENDPOINTS=http://lighthouse:5052
-CHARON_JAEGER_ADDRESS=jaeger:6831
-CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
-CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
-CHARON_MONITORING_ADDRESS=0.0.0.0:3620
-CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
-CHARON_P2P_BOOTNODE_RELAY="true"
-CHARON_LOG_LEVEL=info
-CHARON_JAEGER_SERVICE=charon
-CHARON_P2P_EXTERNAL_HOSTNAME=charon
-CHARON_P2P_BOOTNODES=http://bootnode.lb.gcp.obol.tech:3640/enr
+######### Geth Config #########
+
+# Geth docker container image version, e.g. `latest` or `v1.10.21`.
+# See available tags https://hub.docker.com/r/ethereum/client-go/tags
+#GETH_VERSION=
+
+# Geth host exposed ports
+#GETH_PORT_P2P=
+#GETH_PORT_HTTP=
+#GETH_PORT_AUTH=
+#GETH_PORT_METRICS=
+
+######### Lighthouse Config #########
+
+# Lighthouse beacon node docker container image version, e.g. `latest` or `v2.0.1`.
+# See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
+#LIGHTHOUSE_VERSION=
+
+# Lighthouse beacon node host exposed ports
+#LIGHTHOUSE_PORT_P2P=
+#LIGHTHOUSE_PORT_METRICS=
+
+######### Teku Config #########
+
+# Teku validator client docker container image version, e.g. `latest` or `22.3.1`.
+# See available tags https://hub.docker.com/r/consensys/teku/tags
+#TEKU_VERSION=
+
+# Teku beacon node host exposed ports
+#TEKU_PORT_METRICS=
+
+######### Charon Config #########
+
+# Charon docker container image version, e.g. `latest` or `df6c9bf`.
+# See available tags https://hub.docker.com/r/obolnetwork/charon/tags.
+#CHARON_VERSION=
+
+# Define custom bootnodes. One or more ENRs or an http URL that return an ENR. Use a comma seperated list excluding spaces.
+#CHARON_P2P_BOOTNODES=
+
+# Connect to one or more external beacon nodes. Use a comma seperated list excluding spaces.
+#CHARON_BEACON_NODE_ENDPOINTS=
+
+# Override the charon logging level; debug, info, warning, error.
+#CHARON_LOG_LEVEL=
+
+# Disable P2P bootnode relay if all peers are directly accessible.
+#CHARON_P2P_BOOTNODE_RELAY=false
+
+# Disable Jaeger tracing by setting an empty address.
+#CHARON_JAEGER_ADDRESS=
+
+# Advertise a custom external DNS hostname or IP address for UDP discv5 peer discovery.
+#CHARON_P2P_EXTERNAL_HOSTNAME=
+
+# Charon host exposed ports
+#CHARON_PORT_VALIDATOR_API=
+#CHARON_PORT_P2P_TCP=
+#CHARON_PORT_MONITORING=
+#CHARON_PORT_P2P_UDP=
+
+# Monitoring host exposed ports
+#MONITORING_PORT_PROMETHEUS=
+#MONITORING_PORT_GRAFANA=
+#MONITORING_PORT_JAEGER=

--- a/README.md
+++ b/README.md
@@ -49,21 +49,19 @@ If you are taking part in an organised Obol testnet, submit the created ENR publ
 
 ## Step 2. Leader creates the DKG configuration file and distributes it to everyone else
 
-One person, in the cluster or otherwise, will prepare the configuration file for the distributed key generation ceremony using the `charon create dkg` command. For the official Obol testnets, this step will be completed by an Obol core team member or the cluster captain and the definition file will be distributed to the cluster members for DKG completion.
+One person, in the cluster or otherwise, will prepare the `cluster-definition.json` file for the distributed key generation ceremony using the `charon create dkg` command. For the official Obol testnets, this step will be completed by an Obol core team member or the cluster captain and the definition file will be distributed to the cluster members for DKG completion.
 
 In future, step 1 and step 2 of this guide will use the [Obol Distributed Validator Launchpad](https://docs.obol.tech/docs/dvk/distributed_validator_launchpad) to facilitate and verify these files are created in an authenticated manner.
 
 ```
 # Prepare an environment variable file
-cp .env.sample .env
+cp .env.create_dkg.sample .env.create_dkg
 
-# Set the ENRs of all the operators participating in the DKG ceremony in the .env file variable CHARON_OPERATOR_ENRS
+# Populate the .env.create_dkg file with the cluster name, the fee recipient and withdrawal Ethereum addresses and the 
+# operator ENRs of all the operators participating in the DKG ceremony.
 
-# Set FEE_RECIPIENT_ADDRESS and WITHDRAWAL_ADDRESS to ETH1 addresses of your choice.
-# NAME can be any random string like "Obol Team"
-docker run --rm -v "$(pwd):/opt/charon" --env-file .env obolnetwork/charon:v0.10.0 create dkg --name=$NAME --fee-recipient-address=$FEE_RECIPIENT_ADDRESS --withdrawal-address=$WITHDRAWAL_ADDRESS
-
-# The above command prepares a DKG configuration file.
+# Run the `charon create dkg` command that generates DKG cluster-definition.json file.
+docker run --rm -v "$(pwd):/opt/charon" --env-file .env.create_dkg obolnetwork/charon:v0.10.0 create dkg
 ```
 
 This command should output a file at `.charon/cluster-definition.json`. This file needs to be shared with the other operators in a cluster.
@@ -192,7 +190,7 @@ Ensure the ENR returned by the bootnode contains the correct public IP and port 
 Configure **ALL** charon nodes in your cluster to use this bootnode:
 
 - Either by adding a flag: `--p2p-bootnodes=http://replace.with.public.ip.or.hostname:3640/enr`
-- Or by setting the environment variable: `CHARON_P2P_BOOTNODES=http://replace.with.public.ip.or.hostname:3640/enr`
+- Or by setting the environment variable in the `.env` file: `CHARON_P2P_BOOTNODES=http://replace.with.public.ip.or.hostname:3640/enr`
 
 Note that a local `boonode/.charon/charon-enr-private-key` file will be created next to `bootnode/docker-compose.yml` to ensure a persisted bootnode ENR across restarts.
 
@@ -271,9 +269,7 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
      - If it isn't `charon-distributed-validator-node-dvnode`, then update `compose-volutary-exit.yml` accordingly.
    - Ensure the latest fork version epoch is used:
      - Voluntary exists require an epoch after which they take effect.
-     - All VCs need to sign and submit the exact same messages (epoch) in DVT.
-     - `--epoch=1` would be ideal, since all chains have that epoch in the past, so the validator should exit immediately.
-     - There is however a [bug](https://github.com/sigp/lighthouse/issues/3471) in lighthouse requiring an epoch that maps to the latest fork version to be used.
+     - All VCs need to sign and submit the exact same messages (epoch) in DVT. Using the epoch of the latest fork version is well known option.
      - `compose-volutary-exit.yml` is configured with `--epoch=112260` which is the latest Bellatrix fork on Prater.
      - If the Charon cluster is running on a different chain, **ALL** operators must update `--epoch` to the same latest fork version returned by `curl $BEACON_NODE/eth/v1/config/fork_schedule`.
    - Run the command to submit this node's partially signed voluntary exit:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 version: "3.8"
 
+# Override any defaults specified by `${FOO:-bar}` in `.env` with `FOO=qux`.
+
 services:
   #             _   _
   #   __ _  ___| |_| |__
@@ -9,14 +11,13 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:v1.10.23
+    image: ethereum/client-go:${GETH_VERSION:-v1.10.23}
     ports:
-      - 30303:30303/tcp
-      - 30303:30303/udp
-      - 8545:8545
-      - 8551:8551/tcp
-      - 8551:8551/udp
-      - 6060:6060
+      - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
+      - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
+      - ${GETH_PORT_HTTP:-8545}:8545      # JSON-RPC
+      - ${GETH_PORT_AUTH:-8551}:8551      # AUTH-RPC
+      - ${GETH_PORT_METRICS:-6060}:6060   # Metrics
     command: |
       --goerli
       --http
@@ -45,13 +46,13 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:v3.0.0
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v3.0.0}
     depends_on:
       - geth
     ports:
-      - 9000:9000/tcp
-      - 9000:9000/udp
-      - 5052:5052
+      - ${LIGHTHOUSE_PORT_P2P:-9000}:30303/tcp    # P2P TCP
+      - ${LIGHTHOUSE_PORT_P2P:-9000}:30303/udp    # P2P UDP
+      - ${LIGHTHOUSE_PORT_METRICS:-5052}:5052     # Metrics
     command: |
       lighthouse bn
       --network=goerli
@@ -79,16 +80,27 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:${CHARON_VERSION}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.10.0}
     depends_on:
       - lighthouse
-    env_file: .env
+    environment:
+      - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
+      - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
+      - CHARON_P2P_BOOTNODES=${CHARON_P2P_BOOTNODES:-http://bootnode.lb.gcp.obol.tech:3640/enr}
+      - CHARON_P2P_BOOTNODE_RELAY=${CHARON_P2P_BOOTNODE_RELAY:-true}
+      - CHARON_P2P_EXTERNAL_HOSTNAME=${CHARON_P2P_EXTERNAL_HOSTNAME:-} # Empty default required to avoid warnings.
+      - CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
+      - CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
+      - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
+      - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
+      - CHARON_JAEGER_ADDRESS=${CHARON_JAEGER_ADDRESS-jaeger:6831} # Overriding to empty address allowed
+      - CHARON_JAEGER_SERVICE=charon
+    entrypoint: [printenv]
     ports:
-      - 3600:3600/tcp # Validator API
-      - 3610:3610/tcp # Libp2p
-      - 3620:3620/tcp # Monitoring
-      - 3630:3630/udp # Discv5
+      - ${CHARON_PORT_VALIDATOR_API:-3600}:3600/tcp # Validator API
+      - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p
+      - ${CHARON_PORT_MONITORING:-3620}:3620/tcp    # Monitoring
+      - ${CHARON_PORT_P2P_UDP:-3630}:3630/udp       # P2P UDP discv5
     networks: [dvnode]
     volumes:
       - .charon:/opt/charon/.charon
@@ -103,12 +115,12 @@ services:
   #  \__\___|_|\_\\__,_|
 
   teku:
-    image: consensys/teku:22.8.1
+    image: consensys/teku:${TEKU_VERSION:-22.9}
     depends_on:
       - charon
       - lighthouse
     ports:
-      - 8008:8008
+      - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
     command: |
       validator-client
       --config-file "/opt/charon/teku/teku_config.yaml"
@@ -129,7 +141,7 @@ services:
     image: prom/prometheus:v2.38.0
     user: ":"
     ports:
-      - "9090:9090"
+      - ${MONITORING_PORT_PROMETHEUS:-9090}:9090
     networks: [dvnode]
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
@@ -140,7 +152,7 @@ services:
     user: ":"
     depends_on: [prometheus]
     ports:
-      - "3000:3000"
+      - ${MONITORING_PORT_GRAFANA:-3000}:3000
     networks: [dvnode]
     volumes:
       - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
@@ -151,14 +163,12 @@ services:
 
   node-exporter:
     image: prom/node-exporter:latest
-    ports:
-      - "9100:9100"
     networks: [dvnode]
 
   jaeger:
     image: jaegertracing/all-in-one:latest
     ports:
-      - "16686:16686"
+      - ${MONITORING_PORT_JAEGER:-16686}:16686
     networks: [dvnode]
 
 networks:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -50,8 +50,8 @@ services:
     depends_on:
       - geth
     ports:
-      - ${LIGHTHOUSE_PORT_P2P:-9000}:30303/tcp    # P2P TCP
-      - ${LIGHTHOUSE_PORT_P2P:-9000}:30303/udp    # P2P UDP
+      - ${LIGHTHOUSE_PORT_P2P:-30303}:30303/tcp   # P2P TCP
+      - ${LIGHTHOUSE_PORT_P2P:-30303}:30303/udp   # P2P UDP
       - ${LIGHTHOUSE_PORT_METRICS:-5052}:5052     # Metrics
     command: |
       lighthouse bn

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,6 @@ services:
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_JAEGER_ADDRESS=${CHARON_JAEGER_ADDRESS-jaeger:6831} # Overriding to empty address allowed
       - CHARON_JAEGER_SERVICE=charon
-    entrypoint: [printenv]
     ports:
       - ${CHARON_PORT_VALIDATOR_API:-3600}:3600/tcp # Validator API
       - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p


### PR DESCRIPTION
Refactors the `docker-compose.yml` file to contain defaults that can be overwritten in the `.env` file.

This aims to keep custom config away from the checked-in "official" config. Users should be able to update to latest by `git pull` without any merge conflicts since their custom config would not interfere. It also allows Obol to define default values while users can still overwrite them.

Fixes: #87

