### PR TITLE
support any custom charon config

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -56,6 +56,9 @@
 # Advertise a custom external DNS hostname or IP address for UDP discv5 peer discovery.
 #CHARON_P2P_EXTERNAL_HOSTNAME=
 
+# Custom env file containing additional charon config flags
+#CHARON_CUSTOM_ENV_FILE=.env.charon.custom
+
 # Charon host exposed ports
 #CHARON_PORT_VALIDATOR_API=
 #CHARON_PORT_P2P_TCP=

--- a/README.md
+++ b/README.md
@@ -233,6 +233,13 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
    - So just copy `.env.sample` to `.env` and the update any of the variables to your custom value.
    - Note that **only** variables defined in `docker-compose.yml` can be overridden this way.
 
+6. How do configure `charon` with additional flags not provided in `docker-compose.yml`?
+
+   - As mentioned above, users can override config in `docker-compose.yml` via env vars in `.env`. But charon has a lot more config flags available than those few specified in `docker-compose.yml`.
+   - To customise and configure any additional config flags in charon, create a new `.env.charon.custom` file.
+   - Populate any [config flags supported by charon](https://github.com/ObolNetwork/charon/blob/main/docs/configuration.md#configuration-options) as env var using upper case prefixed with `CHARON`, ie. `CHARON_LOG_FORMAT=logfmt`
+   - Enable additional custom config by uncommenting `#CHARON_CUSTOM_ENV_FILE=.env.charon.custom` in `.env`.
+
 7. Why does Teku throw a keystore file error?
 
    - Teku sometimes logs an error which looks like:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,6 +95,8 @@ services:
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_JAEGER_ADDRESS=${CHARON_JAEGER_ADDRESS-jaeger:6831} # Overriding to empty address allowed
       - CHARON_JAEGER_SERVICE=charon
+    env_file:
+      - ${CHARON_CUSTOM_ENV_FILE:-} # Empty default require to avoid warnings.
     ports:
       - ${CHARON_PORT_VALIDATOR_API:-3600}:3600/tcp # Validator API
       - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p


### PR DESCRIPTION
Add support for any custom charon config flags without modifying `docker-compose.yml`.