### PR TITLE
remove broken env-file option

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -56,9 +56,6 @@
 # Advertise a custom external DNS hostname or IP address for UDP discv5 peer discovery.
 #CHARON_P2P_EXTERNAL_HOSTNAME=
 
-# Custom env file containing additional charon config flags
-#CHARON_CUSTOM_ENV_FILE=.env.charon.custom
-
 # Charon host exposed ports
 #CHARON_PORT_VALIDATOR_API=
 #CHARON_PORT_P2P_TCP=

--- a/README.md
+++ b/README.md
@@ -233,21 +233,14 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
    - So just copy `.env.sample` to `.env` and the update any of the variables to your custom value.
    - Note that **only** variables defined in `docker-compose.yml` can be overridden this way.
 
-6. How do configure `charon` with additional flags not provided in `docker-compose.yml`?
-
-   - As mentioned above, users can override config in `docker-compose.yml` via env vars in `.env`. But charon has a lot more config flags available than those few specified in `docker-compose.yml`.
-   - To customise and configure any additional config flags in charon, create a new `.env.charon.custom` file.
-   - Populate any [config flags supported by charon](https://github.com/ObolNetwork/charon/blob/main/docs/configuration.md#configuration-options) as env var using upper case prefixed with `CHARON`, ie. `CHARON_LOG_FORMAT=logfmt`
-   - Enable additional custom config by uncommenting `#CHARON_CUSTOM_ENV_FILE=.env.charon.custom` in `.env`.
-
-7. Why does Teku throw a keystore file error?
+6. Why does Teku throw a keystore file error?
 
    - Teku sometimes logs an error which looks like:
      `Keystore file /opt/charon/validator_keys/keystore-0.json.lock already in use.`
    - This can be solved by deleting the file(s) ending with `.lock` in the folder `.charon/validator_keys`.
    - It is caused by an unsafe shut down of Teku (usually by double pressing Ctrl+C to shutdown containers faster).
 
-8. How to fix the grafana dashboard?
+7. How to fix the grafana dashboard?
 
    - Sometimes, grafana dashboard doesn't load any data first time around
    - You can solve this by following the steps below:
@@ -256,7 +249,7 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
      - Change the "Access" field from `Server (default)` to `Browser`. Press "Save & Test". It should fail.
      - Change the "Access" field back to `Server (default)` and press "Save & Test". You should be presented with a green success icon saying "Data source is working" and you can return to the dashboard page.
 
-9. How to fix `permission denied` errors?
+8. How to fix `permission denied` errors?
 
    - Permission denied errors can come up in a variety of manners, particularly on Linux and WSL for Windows systems.
    - In the interest of security, the charon docker image runs as a non-root user, and this user often does not have the permissions to write in the directory you have checked out the code to.
@@ -266,17 +259,17 @@ Keep checking in for updates, [here](https://github.com/ObolNetwork/charon/#supp
        - `mkdir .charon` (if it doesn't already exist)
        - `sudo chmod -R 666 .charon`
 
-10. I see a lot of errors after running `docker-compose up`.
+9. I see a lot of errors after running `docker-compose up`.
 
-    - It's because both `geth` and `lighthouse` start syncing and so there's connectivity issues among the containers.
-    - Simply let the containers run for a while. You won't observe frequent errors when geth finishes syncing.
-    - You can also add a second beacon node endpoint for something like infura by adding a comma separated API URL to the end of `CHARON_BEACON_NODE_ENDPOINTS` in the [docker-compose](./docker-compose.yml#84).
+   - It's because both `geth` and `lighthouse` start syncing and so there's connectivity issues among the containers.
+   - Simply let the containers run for a while. You won't observe frequent errors when geth finishes syncing.
+   - You can also add a second beacon node endpoint for something like infura by adding a comma separated API URL to the end of `CHARON_BEACON_NODE_ENDPOINTS` in the [docker-compose](./docker-compose.yml#84).
 
-11. When starting the standalone bootnode, I get a `resolve IP of p2p external host flag: lookup replace.with.public.ip.or.hostname: no such host` error
+10. When starting the standalone bootnode, I get a `resolve IP of p2p external host flag: lookup replace.with.public.ip.or.hostname: no such host` error
 
     - Replace `replace.with.public.ip.or.hostname` in the bootnode/docker-compose.yml with your real public IP or DNS hostname.
 
-12. How do I voluntary exit a validator?
+11. How do I voluntary exit a validator?
     - A voluntary exit is when a validator chooses to stop performing its duties, and exits the beacon chain permanently. To voluntarily exit, the validator must continue performing its validator duties until successfully exited to avoid penalties.
     - To trigger a voluntary exit, a sidecar docker-compose command is executed that signs and submits the voluntary exit to the active running charon node that shares it with other nodes in the cluster. The commands below should be executed on the same machine and same folder as the active running charon-distribute-validator-node docker compose.
     - To override any default config defined in `compose-volutary-exit.yml`, copy `.env.sample` to `.env` and update any of the "Voluntary Exit Config" env vars.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -106,69 +106,69 @@ services:
     restart: on-failure
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
-#
-#  #  _       _
-#  # | |_ ___| | ___   _
-#  # | __/ _ \ |/ / | | |
-#  # | ||  __/   <| |_| |
-#  #  \__\___|_|\_\\__,_|
-#
-#  teku:
-#    image: consensys/teku:${TEKU_VERSION:-22.9.1}
-#    depends_on:
-#      - charon
-#      - lighthouse
-#    ports:
-#      - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
-#    command: |
-#      validator-client
-#      --config-file "/opt/charon/teku/teku_config.yaml"
-#    networks: [dvnode]
-#    volumes:
-#      - ".charon/validator_keys:/opt/charon/validator_keys"
-#      - "./config:/opt/charon/teku"
-#    restart: on-failure
-#
-#  #                        _ _             _
-#  #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _
-#  # | '_ ` _ \ / _ \| '_ \| | __/ _ \| '__| | '_ \ / _` |
-#  # | | | | | | (_) | | | | | || (_) | |  | | | | | (_| |
-#  # |_| |_| |_|\___/|_| |_|_|\__\___/|_|  |_|_| |_|\__, |
-#  #                                                |___/
-#
-#  prometheus:
-#    image: prom/prometheus:v2.38.0
-#    user: ":"
-#    ports:
-#      - ${MONITORING_PORT_PROMETHEUS:-9090}:9090
-#    networks: [dvnode]
-#    volumes:
-#      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-#      - ./data/prometheus:/prometheus
-#
-#  grafana:
-#    image: grafana/grafana:9.0.7
-#    user: ":"
-#    depends_on: [prometheus]
-#    ports:
-#      - ${MONITORING_PORT_GRAFANA:-3000}:3000
-#    networks: [dvnode]
-#    volumes:
-#      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
-#      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/datasource.yml
-#      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
-#      - ./grafana/dashboards:/etc/dashboards
-#      - ./data/grafana:/var/lib/grafana
-#
-#  node-exporter:
-#    image: prom/node-exporter:latest
-#    networks: [dvnode]
-#
-#  jaeger:
-#    image: jaegertracing/all-in-one:latest
-#    ports:
-#      - ${MONITORING_PORT_JAEGER:-16686}:16686
-#    networks: [dvnode]
+
+  #  _       _
+  # | |_ ___| | ___   _
+  # | __/ _ \ |/ / | | |
+  # | ||  __/   <| |_| |
+  #  \__\___|_|\_\\__,_|
+
+  teku:
+    image: consensys/teku:${TEKU_VERSION:-22.9.1}
+    depends_on:
+      - charon
+      - lighthouse
+    ports:
+      - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
+    command: |
+      validator-client
+      --config-file "/opt/charon/teku/teku_config.yaml"
+    networks: [dvnode]
+    volumes:
+      - ".charon/validator_keys:/opt/charon/validator_keys"
+      - "./config:/opt/charon/teku"
+    restart: on-failure
+
+  #                        _ _             _
+  #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _
+  # | '_ ` _ \ / _ \| '_ \| | __/ _ \| '__| | '_ \ / _` |
+  # | | | | | | (_) | | | | | || (_) | |  | | | | | (_| |
+  # |_| |_| |_|\___/|_| |_|_|\__\___/|_|  |_|_| |_|\__, |
+  #                                                |___/
+
+  prometheus:
+    image: prom/prometheus:v2.38.0
+    user: ":"
+    ports:
+      - ${MONITORING_PORT_PROMETHEUS:-9090}:9090
+    networks: [dvnode]
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+      - ./data/prometheus:/prometheus
+
+  grafana:
+    image: grafana/grafana:9.0.7
+    user: ":"
+    depends_on: [prometheus]
+    ports:
+      - ${MONITORING_PORT_GRAFANA:-3000}:3000
+    networks: [dvnode]
+    volumes:
+      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/datasource.yml
+      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
+      - ./grafana/dashboards:/etc/dashboards
+      - ./data/grafana:/var/lib/grafana
+
+  node-exporter:
+    image: prom/node-exporter:latest
+    networks: [dvnode]
+
+  jaeger:
+    image: jaegertracing/all-in-one:latest
+    ports:
+      - ${MONITORING_PORT_JAEGER:-16686}:16686
+    networks: [dvnode]
 
 networks:
   dvnode:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,8 +95,6 @@ services:
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_JAEGER_ADDRESS=${CHARON_JAEGER_ADDRESS-jaeger:6831} # Overriding to empty address allowed
       - CHARON_JAEGER_SERVICE=charon
-    env_file:
-      - ${CHARON_CUSTOM_ENV_FILE:-} # Empty default require to avoid warnings.
     ports:
       - ${CHARON_PORT_VALIDATOR_API:-3600}:3600/tcp # Validator API
       - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p
@@ -108,69 +106,69 @@ services:
     restart: on-failure
     healthcheck:
       test: wget -qO- http://localhost:3620/readyz
-
-  #  _       _
-  # | |_ ___| | ___   _
-  # | __/ _ \ |/ / | | |
-  # | ||  __/   <| |_| |
-  #  \__\___|_|\_\\__,_|
-
-  teku:
-    image: consensys/teku:${TEKU_VERSION:-22.9.1}
-    depends_on:
-      - charon
-      - lighthouse
-    ports:
-      - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
-    command: |
-      validator-client
-      --config-file "/opt/charon/teku/teku_config.yaml"
-    networks: [dvnode]
-    volumes:
-      - ".charon/validator_keys:/opt/charon/validator_keys"
-      - "./config:/opt/charon/teku"
-    restart: on-failure
-
-  #                        _ _             _
-  #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _
-  # | '_ ` _ \ / _ \| '_ \| | __/ _ \| '__| | '_ \ / _` |
-  # | | | | | | (_) | | | | | || (_) | |  | | | | | (_| |
-  # |_| |_| |_|\___/|_| |_|_|\__\___/|_|  |_|_| |_|\__, |
-  #                                                |___/
-
-  prometheus:
-    image: prom/prometheus:v2.38.0
-    user: ":"
-    ports:
-      - ${MONITORING_PORT_PROMETHEUS:-9090}:9090
-    networks: [dvnode]
-    volumes:
-      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
-      - ./data/prometheus:/prometheus
-
-  grafana:
-    image: grafana/grafana:9.0.7
-    user: ":"
-    depends_on: [prometheus]
-    ports:
-      - ${MONITORING_PORT_GRAFANA:-3000}:3000
-    networks: [dvnode]
-    volumes:
-      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
-      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/datasource.yml
-      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
-      - ./grafana/dashboards:/etc/dashboards
-      - ./data/grafana:/var/lib/grafana
-
-  node-exporter:
-    image: prom/node-exporter:latest
-    networks: [dvnode]
-
-  jaeger:
-    image: jaegertracing/all-in-one:latest
-    ports:
-      - ${MONITORING_PORT_JAEGER:-16686}:16686
-    networks: [dvnode]
+#
+#  #  _       _
+#  # | |_ ___| | ___   _
+#  # | __/ _ \ |/ / | | |
+#  # | ||  __/   <| |_| |
+#  #  \__\___|_|\_\\__,_|
+#
+#  teku:
+#    image: consensys/teku:${TEKU_VERSION:-22.9.1}
+#    depends_on:
+#      - charon
+#      - lighthouse
+#    ports:
+#      - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
+#    command: |
+#      validator-client
+#      --config-file "/opt/charon/teku/teku_config.yaml"
+#    networks: [dvnode]
+#    volumes:
+#      - ".charon/validator_keys:/opt/charon/validator_keys"
+#      - "./config:/opt/charon/teku"
+#    restart: on-failure
+#
+#  #                        _ _             _
+#  #  _ __ ___   ___  _ __ (_) |_ ___  _ __(_)_ __   __ _
+#  # | '_ ` _ \ / _ \| '_ \| | __/ _ \| '__| | '_ \ / _` |
+#  # | | | | | | (_) | | | | | || (_) | |  | | | | | (_| |
+#  # |_| |_| |_|\___/|_| |_|_|\__\___/|_|  |_|_| |_|\__, |
+#  #                                                |___/
+#
+#  prometheus:
+#    image: prom/prometheus:v2.38.0
+#    user: ":"
+#    ports:
+#      - ${MONITORING_PORT_PROMETHEUS:-9090}:9090
+#    networks: [dvnode]
+#    volumes:
+#      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
+#      - ./data/prometheus:/prometheus
+#
+#  grafana:
+#    image: grafana/grafana:9.0.7
+#    user: ":"
+#    depends_on: [prometheus]
+#    ports:
+#      - ${MONITORING_PORT_GRAFANA:-3000}:3000
+#    networks: [dvnode]
+#    volumes:
+#      - ./grafana/datasource.yml:/etc/grafana/provisioning/datasources/datasource.yml
+#      - ./grafana/dashboards.yml:/etc/grafana/provisioning/dashboards/datasource.yml
+#      - ./grafana/grafana.ini:/etc/grafana/grafana.ini:ro
+#      - ./grafana/dashboards:/etc/dashboards
+#      - ./data/grafana:/var/lib/grafana
+#
+#  node-exporter:
+#    image: prom/node-exporter:latest
+#    networks: [dvnode]
+#
+#  jaeger:
+#    image: jaegertracing/all-in-one:latest
+#    ports:
+#      - ${MONITORING_PORT_JAEGER:-16686}:16686
+#    networks: [dvnode]
 
 networks:
   dvnode:


### PR DESCRIPTION
Removes the custom config env-file override which doesn't work if the override isn't present.

This cases the `ERROR: /Users/path/charon-distributed-validator-node is not a file.`