### PR TITLE
Support docker-compose.override.yml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 .env
+.env.charon.more
+docker-compose.override.yml
 charon-enr-private-key
 validator_keys/
 keystore-*

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -24,7 +24,7 @@ services:
     #profiles: [disable]
 
   charon:
-    # Configure any addition env var flags in .env.charon.more
+    # Configure any additional env var flags in .env.charon.more
     #env_file: [.env.charon.more]
 
   teku:

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -6,9 +6,10 @@
 # Just copy this file to `docker-compose.override.yml` and customise it to your liking.
 # `cp docker-compose.override.yml.sample docker-compose.override.yml`
 
-# Some example overrides are commented out below, any uncommented section
+# Some example overrides are commented out below. Any uncommented section
 # below will automatically override the same section in
 # docker-compose.yml when ran with `docker-compose up`.
+# See https://docs.docker.com/compose/extends/#adding-and-overriding-configuration for details.
 
 # WARNING: This is for power users only and requires a deep understanding of Docker Compose
 # and how the local docker-compose.yml is configured.
@@ -19,19 +20,13 @@ services:
     #profiles: [disable]
 
   lighthouse:
-    # Remove dependency if geth disabled
-    #depends_on: []
-
     # Disable lighthouse
     #profiles: [disable]
 
   charon:
-    # Remove dependency if lighthouse disabled
-    #depends_on: []
-
     # Configure any addition env var flags in .env.charon.more
-    #env-file: [.env.charon.more]
+    #env_file: [.env.charon.more]
 
   teku:
     # Disable teku
-    #profiles: [teku]
+    #profiles: [disable]

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -1,0 +1,37 @@
+# The "Multiple Compose File" feature provides a very powerful way to override
+# any configuration in docker-compose.yml without needing to modify
+# git-checked-in files since that results in conflicts when upgrading this repo.
+# See https://docs.docker.com/compose/extends/#multiple-compose-files for more.
+
+# Just copy this file to `docker-compose.override.yml` and customise it to your liking.
+# `cp docker-compose.override.yml.sample docker-compose.override.yml`
+
+# Some example overrides are commented out below, any uncommented section
+# below will automatically override the same section in
+# docker-compose.yml when ran with `docker-compose up`.
+
+# WARNING: This is for power users only and requires a deep understanding of Docker Compose
+# and how the local docker-compose.yml is configured.
+
+services:
+  geth:
+    # Disable geth
+    #profiles: [disable]
+
+  lighthouse:
+    # Remove dependency if geth disabled
+    #depends_on: []
+
+    # Disable lighthouse
+    #profiles: [disable]
+
+  charon:
+    # Remove dependency if lighthouse disabled
+    #depends_on: []
+
+    # Configure any addition env var flags in .env.charon.more
+    #env-file: [.env.charon.more]
+
+  teku:
+    # Disable teku
+    #profiles: [teku]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -117,7 +117,6 @@ services:
     image: consensys/teku:${TEKU_VERSION:-22.9.1}
     depends_on:
       - charon
-      - lighthouse
     ports:
       - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
     command: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -47,8 +47,6 @@ services:
 
   lighthouse:
     image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v3.1.0}
-    depends_on:
-      - geth
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP
@@ -81,8 +79,6 @@ services:
 
   charon:
     image: obolnetwork/charon:${CHARON_VERSION:-v0.10.0}
-    depends_on:
-      - lighthouse
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
@@ -115,8 +111,6 @@ services:
 
   teku:
     image: consensys/teku:${TEKU_VERSION:-22.9.1}
-    depends_on:
-      - charon
     ports:
       - ${TEKU_PORT_METRICS:-8008}:8008 # Metrics
     command: |
@@ -148,7 +142,6 @@ services:
   grafana:
     image: grafana/grafana:9.0.7
     user: ":"
-    depends_on: [prometheus]
     ports:
       - ${MONITORING_PORT_GRAFANA:-3000}:3000
     networks: [dvnode]


### PR DESCRIPTION
Adds support for a `docker-compose.override.yml` file to disable services in the stack. Also add a sample file with instructions on how it works.

Remove `depends_on` in docker-compose since:
 - It creates very strong coupling between services
 - Which cannot be removed by a override file