### PR TITLE
Bump charon version to `v0.11.0`

### DIFF
--- a/bootnode/docker-compose.yml
+++ b/bootnode/docker-compose.yml
@@ -8,7 +8,7 @@ services:
   # |_.__/ \___/ \___/ \__|_| |_|\___/ \__,_|\___|
   bootnode:
     # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:v0.10.1
+    image: obolnetwork/charon:v0.11.0
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630


### PR DESCRIPTION
Reverts ObolNetwork/charon-distributed-validator-node#119