### PR TITLE
remove keystore locking flag from voluntary-exit command

### DIFF
--- a/compose-voluntary-exit.yml
+++ b/compose-voluntary-exit.yml
@@ -11,7 +11,6 @@ services:
     command: |
       voluntary-exit
       --beacon-node-api-endpoint="http://charon:3600"
-      --validators-keystore-locking-enabled=false
       --confirmation-enabled=false
       --validator-keys="/opt/charon/exit_keys:/opt/charon/exit_keys"
       --epoch=${EXIT_EPOCH:-112260}


### PR DESCRIPTION
Removes keystore locking flag voluntary-exit command of teku in `compose-voluntary-exit.yml`.