### PR TITLE
expose p2p ports

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -7,11 +7,17 @@
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 
+# Geth host exposed ports
+#GETH_PORT_P2P=
+
 ######### Lighthouse Config #########
 
 # Lighthouse beacon node docker container image version, e.g. `latest` or `v3.2.0`.
 # See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
 #LIGHTHOUSE_VERSION=
+
+# Lighthouse beacon node host exposed ports
+#LIGHTHOUSE_PORT_P2P=
 
 ######### Teku Config #########
 
@@ -48,6 +54,10 @@
 
 # Docker network of running charon node. See `docker network ls`.
 #CHARON_DOCKER_NETWORK=
+
+# Charon host exposed ports
+#CHARON_PORT_P2P_TCP=
+#CHARON_PORT_P2P_UDP=
 
 ######### Monitoring Config #########
 

--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -18,9 +18,8 @@
   #geth:
     # Disable geth
     #profiles: [disable]
-    #ports: # Bind geth internal ports to host ports
-      #- 30303:30303/tcp # P2P TCP
-      #- 30303:30303/udp # P2P UDP
+    # Bind geth internal ports to host ports
+    #ports:
       #- 8545:8545 # JSON-RPC
       #- 8551:8551 # AUTH-RPC
       #- 6060:6060 # Metrics
@@ -28,35 +27,36 @@
   #lighthouse:
     # Disable lighthouse
     #profiles: [disable]
+    # Bind lighthouse internal ports to host ports
     #ports:
-      #- 9000:9000/tcp # P2P TCP
-      #- 9000:9000/udp # P2P UDP
       #- 5052:5052 # HTTP
       #- 5054:5054 # Metrics
 
   #charon:
     # Configure any additional env var flags in .env.charon.more
     #env_file: [.env.charon.more]
+    # Bind charon internal ports to host ports
     #ports:
       #- 3600:3600/tcp # Validator API
-      #- 3610:3610/tcp # P2P TCP libp2p
       #- 3620:3620/tcp # Monitoring
-      #- 3630:3630/udp # P2P UDP discv5
 
   #teku:
     # Disable teku
     #profiles: [disable]
+    # Bind teku internal ports to host ports
     #ports:
       #- 8008:8008 # Metrics
 
   #prometheus:
     # Disable prometheus
     #profiles: [disable]
+    # Bind prometheus internal ports to host ports
     #ports:
       #- 9090:9090 # Metrics
 
   #loki:
     # Disable loki
     #profiles: [disable]
+    # Bind loki internal ports to host ports
     #ports:
       #- 3100:3100 # Metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,9 @@ services:
 
   geth:
     image: ethereum/client-go:${GETH_VERSION:-v1.10.26}
+    ports:
+      - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
+      - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
     command: |
       --goerli
       --http
@@ -43,6 +46,9 @@ services:
 
   lighthouse:
     image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v3.2.1}
+    ports:
+      - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
+      - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP
     command: |
       lighthouse bn
       --network=goerli
@@ -84,6 +90,9 @@ services:
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
       - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES-http://loki:3100/loki/api/v1/push} # Overriding to empty address allowed
       - CHARON_LOKI_SERVICE=charon
+    ports:
+      - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p
+      - ${CHARON_PORT_P2P_UDP:-3630}:3630/udp       # P2P UDP discv5
     networks: [dvnode]
     volumes:
       - .charon:/opt/charon/.charon


### PR DESCRIPTION
Exposes host ports for P2P inbound communication for geth, lighthouse and charon docker containers.

ticket: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/128