### PR TITLE
Make port settings for Charon consistent for internal/external

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -84,13 +84,13 @@ services:
       - CHARON_LOG_FORMAT=${CHARON_LOG_FORMAT:-console}
       - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech}
       - CHARON_P2P_EXTERNAL_HOSTNAME=${CHARON_P2P_EXTERNAL_HOSTNAME:-} # Empty default required to avoid warnings.
-      - CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
-      - CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
+      - CHARON_P2P_TCP_ADDRESS=0.0.0.0:${CHARON_PORT_P2P_TCP:-3610}
+      - CHARON_P2P_UDP_ADDRESS=0.0.0.0:${CHARON_PORT_P2P_UDP:-3630}
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
     ports:
-      - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p
-      - ${CHARON_PORT_P2P_UDP:-3630}:3630/udp       # P2P UDP discv5
+      - ${CHARON_PORT_P2P_TCP:-3610}:${CHARON_PORT_P2P_TCP:-3610}/tcp # P2P TCP libp2p
+      - ${CHARON_PORT_P2P_UDP:-3630}:${CHARON_PORT_P2P_UDP:-3630}/udp # P2P UDP discv5
     networks: [dvnode]
     volumes:
       - .charon:/opt/charon/.charon


### PR DESCRIPTION
If the ports which the Charon service runs on (and are connected to on the container side) do not match the ports that are bound to the host, then the incorrect port will be advertised to 'some' Charon peers, which (so we found) can lead to peering issues in 'some' cases. (EG nodes which are colocated with one another)

This may hinder any efforts to add redundancy **_within_** a site, making any 'local' redundancy efforts a semi-pointless consideration. This should be supported in addition to the desires we have for 'distributed' redundancy.

(EG, 2+ nodes **per site**, is better than 1 node per site, right?)