### PR TITLE
update geth and charon versions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,7 +3,7 @@
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.11.3`.
+# Geth docker container image version, e.g. `latest` or `v1.11.4`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.11.3}
+    image: ethereum/client-go:${GETH_VERSION:-v1.11.4}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
@@ -77,7 +77,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.14.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v0.14.1}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}


### PR DESCRIPTION
Updates geth to [v1.11.4](https://github.com/ethereum/go-ethereum/releases/tag/v1.11.4) and charon to `v0.14.1`.