### PR TITLE
remove discv5 UDP references

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -43,7 +43,7 @@
 # Override the charon logging format; console, logfmt, json. Grafana panels require logfmt.
 #CHARON_LOG_FORMAT=
 
-# Advertise a custom external DNS hostname or IP address for UDP discv5 peer discovery.
+# Advertise a custom external DNS hostname or IP address for libp2p peer discovery.
 #CHARON_P2P_EXTERNAL_HOSTNAME=
 
 # Loki log aggregation server addresses. Disable loki log aggregation by setting an empty address.
@@ -54,7 +54,6 @@
 
 # Charon host exposed ports
 #CHARON_PORT_P2P_TCP=
-#CHARON_PORT_P2P_UDP=
 
 ######### MEV-Boost Config #########
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,12 +85,10 @@ services:
       - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech}
       - CHARON_P2P_EXTERNAL_HOSTNAME=${CHARON_P2P_EXTERNAL_HOSTNAME:-} # Empty default required to avoid warnings.
       - CHARON_P2P_TCP_ADDRESS=0.0.0.0:3610
-      - CHARON_P2P_UDP_ADDRESS=0.0.0.0:3630
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
     ports:
       - ${CHARON_PORT_P2P_TCP:-3610}:3610/tcp       # P2P TCP libp2p
-      - ${CHARON_PORT_P2P_UDP:-3630}:3630/udp       # P2P UDP discv5
     networks: [dvnode]
     volumes:
       - .charon:/opt/charon/.charon

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -11,13 +11,11 @@ services:
     image: obolnetwork/charon:v0.13.0
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
-      CHARON_P2P_UDP_ADDRESS: 0.0.0.0:3630
       CHARON_HTTP_ADDRESS: 0.0.0.0:3640
       CHARON_LOG_LEVEL: debug
       CHARON_P2P_EXTERNAL_HOSTNAME: replace.with.public.ip.or.hostname
     ports:
       - 3610:3610/tcp
-      - 3630:3630/udp
       - 3640:3640/tcp
     command: relay
     volumes:


### PR DESCRIPTION
Discv5 UDP has been removed after v0.13. So remove all references.