### PR TITLE
update checkpoint-sync URL

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -19,6 +19,9 @@
 # Lighthouse beacon node host exposed ports
 #LIGHTHOUSE_PORT_P2P=
 
+# Checkpoint sync url used by lighthouse to fast sync.
+#LIGHTHOUSE_CHECKPOINT_SYNC_URL=
+
 ######### Teku Config #########
 
 # Teku validator client docker container image version, e.g. `latest` or `22.10.2`.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,7 +52,7 @@ services:
     command: |
       lighthouse bn
       --network=goerli
-      --checkpoint-sync-url=https://goerli.checkpoint-sync.ethdevops.io
+      --checkpoint-sync-url=${LIGHTHOUSE_CHECKPOINT_SYNC_URL:-https://checkpoint-sync.goerli.ethpandaops.io}
       --execution-endpoint=http://geth:8551
       --execution-jwt=/opt/jwt/jwt.hex
       --datadir=/opt/app/beacon/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.11.4}
+    image: ethereum/client-go:${GETH_VERSION:-v1.11.5}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP


### PR DESCRIPTION
Updates checkpoint-sync URL for lighthouse as the old one is returning dns errors. Also adds an environment variable to override checkpoint-sync URL without changing docker-compose.yml