### PR TITLE
upgrade lighthouse

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,7 +15,7 @@
 
 ######### Lighthouse Config #########
 
-# Lighthouse beacon node docker container image version, e.g. `latest` or `v3.5.1`.
+# Lighthouse beacon node docker container image version, e.g. `latest` or `v4.0.1`.
 # See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
 #LIGHTHOUSE_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.0.1}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.0.2-rc.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP


### PR DESCRIPTION
Updates lighthouse image to `v4.0.2-rc.0`.

This is a high-priority update from the sigmaprime team for the Beacon Node. They recommend that all mainnet users update ASAP to prevent high-CPU usage from interfering with normal node operations (e.g., staking).

See their annoucement: https://discord.com/channels/605577013327167508/711866597308104745/1095877177305739376
