### PR TITLE
Test Exit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,6 @@ data/
 teku/validator/
 # Teku directory for storing logs
 teku/logs/
+
+# Nimbus artefacts for secrets and keys
+nimbus/charon

--- a/docker-compose.lighthouse.override.yml
+++ b/docker-compose.lighthouse.override.yml
@@ -1,0 +1,75 @@
+# The "Multiple Compose File" feature provides a very powerful way to override
+# any configuration in docker-compose.yml without needing to modify
+# git-checked-in files since that results in conflicts when upgrading this repo.
+# See https://docs.docker.com/compose/extends/#multiple-compose-files for more.
+
+# Just copy this file to `docker-compose.override.yml` and customise it to your liking.
+# `cp docker-compose.override.yml.sample docker-compose.override.yml`
+
+# Some example overrides are commented out below. Any uncommented section
+# below will automatically override the same section in
+# docker-compose.yml when ran with `docker-compose up`.
+# See https://docs.docker.com/compose/extends/#adding-and-overriding-configuration for details.
+
+# WARNING: This is for power users only and requires a deep understanding of Docker Compose
+# and how the local docker-compose.yml is configured.
+
+services:
+  geth:
+    # Disable geth
+    profiles: [disable]
+    # Bind geth internal ports to host ports
+    #ports:
+      #- 8545:8545 # JSON-RPC
+      #- 8551:8551 # AUTH-RPC
+      #- 6060:6060 # Metrics
+
+  lighthouse:
+    # Disable lighthouse
+    profiles: [disable]
+    # Bind lighthouse internal ports to host ports
+    #ports:
+      #- 5052:5052 # HTTP
+      #- 5054:5054 # Metrics
+
+  charon:
+    # Configure any additional env var flags in .env.charon.more
+    #env_file: [.env.charon.more]
+    # Bind charon internal ports to host ports
+    #ports:
+      #- 3600:3600/tcp # Validator API
+      #- 3620:3620/tcp # Monitoring
+    command: run --no-verify
+
+  teku:
+    # Disable teku
+    profiles: [disable]
+    # Bind teku internal ports to host ports
+    #ports:
+      #- 8008:8008 # Metrics
+  
+  lighthouse:
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v3.5.1}
+    entrypoint: /opt/lighthouse/run.sh
+    networks: [ dvnode ]
+    depends_on: [ charon ]
+    restart: unless-stopped
+    environment:
+      LIGHTHOUSE_BEACON_NODE_ADDRESS: http://charon:3600
+      ETH2_NETWORK: ${ETH2_NETWORK:-goerli}
+    volumes:
+      - ./lighthouse/run.sh:/opt/lighthouse/run.sh
+      - .charon/validator_keys:/opt/charon/validator_keys
+
+
+  #prometheus:
+    # Disable prometheus
+    #profiles: [disable]
+    # Bind prometheus internal ports to host ports
+    #ports:
+      #- 9090:9090 # Metrics
+
+  #mev-boost:
+    # Bind mev-boost internal ports to host ports
+    #ports:
+      #- 18550:18550 # Metrics

--- a/docker-compose.nimbusvc.override.yml
+++ b/docker-compose.nimbusvc.override.yml
@@ -1,0 +1,72 @@
+# The "Multiple Compose File" feature provides a very powerful way to override
+# any configuration in docker-compose.yml without needing to modify
+# git-checked-in files since that results in conflicts when upgrading this repo.
+# See https://docs.docker.com/compose/extends/#multiple-compose-files for more.
+
+# Just copy this file to `docker-compose.override.yml` and customise it to your liking.
+# `cp docker-compose.override.yml.sample docker-compose.override.yml`
+
+# Some example overrides are commented out below. Any uncommented section
+# below will automatically override the same section in
+# docker-compose.yml when ran with `docker-compose up`.
+# See https://docs.docker.com/compose/extends/#adding-and-overriding-configuration for details.
+
+# WARNING: This is for power users only and requires a deep understanding of Docker Compose
+# and how the local docker-compose.yml is configured.
+
+services:
+  geth:
+    # Disable geth
+    profiles: [disable]
+    # Bind geth internal ports to host ports
+    #ports:
+      #- 8545:8545 # JSON-RPC
+      #- 8551:8551 # AUTH-RPC
+      #- 6060:6060 # Metrics
+
+  lighthouse:
+    # Disable lighthouse
+    profiles: [disable]
+    # Bind lighthouse internal ports to host ports
+    #ports:
+      #- 5052:5052 # HTTP
+      #- 5054:5054 # Metrics
+
+  charon:
+    # Configure any additional env var flags in .env.charon.more
+    #env_file: [.env.charon.more]
+    # Bind charon internal ports to host ports
+    #ports:
+      #- 3600:3600/tcp # Validator API
+      #- 3620:3620/tcp # Monitoring
+    command: run --no-verify
+
+  teku:
+    # Disable teku
+    profiles: [disable]
+    # Bind teku internal ports to host ports
+    #ports:
+      #- 8008:8008 # Metrics
+  
+  nimbus:
+    build: nimbus
+    networks: [ dvnode ]
+    depends_on: [ charon ]
+    restart: unless-stopped
+    environment:
+      NODE: charon
+    volumes:
+      - .charon/validator_keys:/home/validator_keys
+      - ./nimbus:/home/user/data
+
+  #prometheus:
+    # Disable prometheus
+    #profiles: [disable]
+    # Bind prometheus internal ports to host ports
+    #ports:
+      #- 9090:9090 # Metrics
+
+  #mev-boost:
+    # Bind mev-boost internal ports to host ports
+    #ports:
+      #- 18550:18550 # Metrics

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,8 @@ services:
     image: prom/prometheus:${PROMETHEUS_VERSION:-v2.43.0}
     user: ":"
     networks: [dvnode]
+    environment:
+      - PROM_REMOTE_WRITE_TOKEN=${PROM_REMOTE_WRITE_TOKEN}
     volumes:
       - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - ./data/prometheus:/prometheus

--- a/lighthouse/run.sh
+++ b/lighthouse/run.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+
+apt-get update && apt-get install -y curl jq wget
+
+while ! curl "${LIGHTHOUSE_BEACON_NODE_ADDRESS}/eth/v1/node/health" 2>/dev/null; do
+  echo "Waiting for ${LIGHTHOUSE_BEACON_NODE_ADDRESS} to become available..."
+  sleep 5
+done
+
+# Refer: https://lighthouse-book.sigmaprime.io/advanced-datadir.html
+# Running a lighthouse VC involves two steps which needs to run in order:
+# 1. Loading the validator keys
+# 2. Actually running the VC
+
+for f in /opt/charon/validator_keys/keystore-*.json; do
+  echo "Importing key ${f}"
+  lighthouse --network "${ETH2_NETWORK}" account validator import \
+    --reuse-password \
+    --keystore "${f}" \
+    --password-file "${f//json/txt}"
+done
+
+echo "Starting lighthouse validator client for ${NODE}"
+exec lighthouse --network "${ETH2_NETWORK}" validator \
+  --beacon-nodes ${LIGHTHOUSE_BEACON_NODE_ADDRESS} \
+  --suggested-fee-recipient "0x919DB6459E86942e4C9C939FE28B6a99De26f035" \
+  --metrics \
+  --metrics-address "0.0.0.0" \
+  --metrics-allow-origin "*" \
+  --metrics-port "5064" \
+  --use-long-timeouts \

--- a/nimbus/Dockerfile
+++ b/nimbus/Dockerfile
@@ -1,0 +1,7 @@
+FROM statusim/nimbus-eth2:multiarch-v23.3.1 as nimbusbn
+
+FROM statusim/nimbus-validator-client:multiarch-v23.3.1
+
+COPY --from=nimbusbn /home/user/nimbus_beacon_node /home/user/nimbus_beacon_node
+
+ENTRYPOINT ["/home/user/data/run.sh"]

--- a/nimbus/run.sh
+++ b/nimbus/run.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+# Cleanup nimbus directories if they already exist.
+rm -rf /home/user/data/${NODE}
+
+# Refer: https://nimbus.guide/keys.html
+# Running a nimbus VC involves two steps which need to run in order:
+# 1. Importing the validator keys
+# 2. And then actually running the VC
+tmpkeys="/home/validator_keys/tmpkeys"
+mkdir -p ${tmpkeys}
+
+for f in /home/validator_keys/keystore-*.json; do
+  echo "Importing key ${f}"
+
+  # Read password from keystore-*.txt into $password variable.
+  password=$(<"${f//json/txt}")
+
+  # Copy keystore file to tmpkeys/ directory.
+  cp "${f}" "${tmpkeys}"
+
+  # Import keystore with the password.
+  echo "$password" | \
+  /home/user/nimbus_beacon_node deposits import \
+  --data-dir=/home/user/data/${NODE} \
+  /home/validator_keys/tmpkeys
+
+  # Delete tmpkeys/keystore-*.json file that was copied before.
+  filename="$(basename ${f})"
+  rm "${tmpkeys}/${filename}"
+done
+
+# Delete the tmpkeys/ directory since it's no longer needed.
+rm -r ${tmpkeys}
+
+echo "Imported all keys"
+
+# Now run nimbus VC
+exec /home/user/nimbus_validator_client \
+  --data-dir=/home/user/data/"${NODE}" \
+  --beacon-node="http://$NODE:3600" \
+  --doppelganger-detection=false \
+  --metrics \
+  --metrics-address=0.0.0.0

--- a/nimbus/run.sh
+++ b/nimbus/run.sh
@@ -25,6 +25,11 @@ for f in /home/validator_keys/keystore-*.json; do
   --data-dir=/home/user/data/${NODE} \
   /home/validator_keys/tmpkeys
 
+  # Import files into .cache for exit process (TODO:Check if this is needed)
+  source_path="/home/user/data/${NODE}/*"
+  destination_directory="/home/user/.cache/nimbus/BeaconNode/"
+  mkdir -p "$destination_directory" && cp "$source_file" "$destination_directory"
+
   # Delete tmpkeys/keystore-*.json file that was copied before.
   filename="$(basename ${f})"
   rm "${tmpkeys}/${filename}"

--- a/prometheus/prometheus.yml
+++ b/prometheus/prometheus.yml
@@ -30,4 +30,4 @@ scrape_configs:
       - targets: ["node-exporter:9100"]
   - job_name: "cadvisor"
     static_configs:
-      - targets: [ "cadvisor:8080" ]
+      - targets: ["cadvisor:8080"]


### PR DESCRIPTION
This commit introduces Docker Compose overrides to customize the configuration of the Lighthouse and Nimbus VC services. The overrides include specific settings tailored to these services, providing enhanced control and flexibility for their deployment.

- Lighthouse: Customized run.sh to run for a single node.
- Nimbus VC: Customized run.sh to run for a single node. Also added few extra lines of code to copy the keys and secrets into `/home/user/.cache/nimbus/BeaconNode/` folder. The exit command for Nimbus complains of missing files in the path.

This change was added to test Exit commands for Lighthouse and Nimbus.

Related Issue: [https://github.com/ObolNetwork/charon-distributed-validator-node/issues/181](url)
