### PR TITLE
bump versions

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -15,7 +15,7 @@
 
 ######### Lighthouse Config #########
 
-# Lighthouse beacon node docker container image version, e.g. `latest` or `v4.0.1`.
+# Lighthouse beacon node docker container image version, e.g. `latest` or `v4.1.0`.
 # See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
 #LIGHTHOUSE_VERSION=
 
@@ -27,7 +27,7 @@
 
 ######### Teku Config #########
 
-# Teku validator client docker container image version, e.g. `latest` or `22.10.2`.
+# Teku validator client docker container image version, e.g. `latest` or `23.5.0`.
 # See available tags https://hub.docker.com/r/consensys/teku/tags
 #TEKU_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -45,7 +45,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.0.2-rc.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.1.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP
@@ -103,7 +103,7 @@ services:
   #  \__\___|_|\_\\__,_|
 
   teku:
-    image: consensys/teku:${TEKU_VERSION:-23.3.1}
+    image: consensys/teku:${TEKU_VERSION:-23.5.0}
     command: |
       validator-client
       --config-file "/opt/teku_config.yaml"


### PR DESCRIPTION
Bump docker image versions for `lighthouse` BN and `teku` VC.

ticket: https://github.com/ObolNetwork/charon-distributed-validator-node/issues/189 