### PR TITLE
Ensure Lodestar VC process exits gracefully

### DIFF
--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -13,7 +13,7 @@ done
 
 echo "Imported all keys"
 
-node /usr/app/packages/cli/bin/lodestar validator \
+exec node /usr/app/packages/cli/bin/lodestar validator \
     --dataDir="/opt/data" \
     --network="$NETWORK" \
     --metrics=true \


### PR DESCRIPTION
Process started with `exec` will receive the signals sent to the PID. This makes sure that the process is exited gracefully and all cleanup tasks are completed, e.g. unlocking keystores.