### PR TITLE
fix mevboost version

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -2,10 +2,7 @@
 # in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
 # Overrides network for all the relevant services.
-NETWORK=mainnet
-
-# Enables builder api for lodestar and charon services.
-#BUILDER_API_ENABLED=
+#NETWORK=
 
 # Enables builder api for lodestar and charon services.
 #BUILDER_API_ENABLED=

--- a/.env.sample
+++ b/.env.sample
@@ -2,7 +2,10 @@
 # in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
 # Overrides network for all the relevant services.
-#NETWORK=
+NETWORK=mainnet
+
+# Enables builder api for lodestar and charon services.
+#BUILDER_API_ENABLED=
 
 # Enables builder api for lodestar and charon services.
 #BUILDER_API_ENABLED=

--- a/.env.sample
+++ b/.env.sample
@@ -72,7 +72,7 @@ NETWORK=mainnet
 
 ######### MEV-Boost Config #########
 
-# MEV-Boost docker container image version, e.g. `latest` or `v1.5.0`.
+# MEV-Boost docker container image version, e.g. `latest` or `1.5.0`.
 #MEVBOOST_VERSION=
 #MEVBOOST_RELAYS=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     image: obolnetwork/charon:${CHARON_VERSION:-v0.15.0}
     depends_on: [lighthouse]
     environment:
-      - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://192.168.1.10:5052}
+      - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
       - CHARON_LOG_FORMAT=${CHARON_LOG_FORMAT:-console}
       - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -80,7 +80,7 @@ services:
     image: obolnetwork/charon:${CHARON_VERSION:-v0.15.0}
     depends_on: [lighthouse]
     environment:
-      - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
+      - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://192.168.1.10:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
       - CHARON_LOG_FORMAT=${CHARON_LOG_FORMAT:-console}
       - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech}

--- a/mevboost-compose.yml
+++ b/mevboost-compose.yml
@@ -13,7 +13,7 @@ services:
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
-    image: flashbots/mev-boost:${MEVBOOST_VERSION:-v1.5.0}
+    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.5.0}
     command: |
       -${NETWORK:-goerli} 
       -loglevel=debug


### PR DESCRIPTION
Fixes mevboost container image version. 

They broke their semantic versioning by removing the `v` prefix from their releases: https://discord.com/channels/755466764501909692/1014218796795449404/1087341616911630478

