### PR TITLE
add disable profile to mevboost

### DIFF
--- a/docker-compose.override.yml.sample
+++ b/docker-compose.override.yml.sample
@@ -55,6 +55,8 @@
       #- 9090:9090 # Metrics
 
   #mev-boost:
+    # Disable mev-boost
+    #profiles: [disable]
     # Bind mev-boost internal ports to host ports
     #ports:
       #- 18550:18550 # Metrics


### PR DESCRIPTION
Add disable profile to `docker-compose.override.yml`. This enables users to disable the mev-boost container.