### PR TITLE
update lodestar version to v1.9.2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -105,7 +105,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|  
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.8.0}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.9.2}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
Updates lodestar image version to v1.9.2 which contains latest builderonly flag.