### PR TITLE
remove depends on lighthouse for charon

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -78,7 +78,6 @@ services:
 
   charon:
     image: obolnetwork/charon:${CHARON_VERSION:-v0.17.0}
-    depends_on: [lighthouse]
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}


### PR DESCRIPTION
Removes depends on field for charon service to depend on lighthouse. This field is not needed in case if an operator runs its beacon node separately.