### PR TITLE
add network to mev-boost

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -125,6 +125,7 @@ services:
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
     image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.5.0}
+    networks: [dvnode]
     command: |
       -${NETWORK:-goerli} 
       -loglevel=debug


### PR DESCRIPTION
Add network `dv-node` to mev-boost container image.

This fixes the bug in which lighthouse container wasn't able to communicate with the mev-boost container which resulted in logs like:
```
{"code":500,"message":"INTERNAL_SERVER_ERROR: HttpClient(url: http://mev-boost:18550/, kind: request, detail: error trying to connect: dns error: failed to lookup address information: Temporary failure in name resolution)","stacktraces":[]}
```