### PR TITLE
mainnet ready CDVN

### DIFF
--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -2,7 +2,7 @@
 # in docker-compose.yml. Rename this file to `.env` and then uncomment and set any variable below.
 
 # Overrides network for all the relevant services.
-#NETWORK=
+NETWORK=mainnet
 
 # Enables builder api for lodestar VC and charon services.
 #BUILDER_API_ENABLED=
@@ -18,7 +18,7 @@
 
 ######### Lighthouse Config #########
 
-# Lighthouse beacon node docker container image version, e.g. `latest` or `v4.2.0`.
+# Lighthouse beacon node docker container image version, e.g. `latest` or `v4.5.0`.
 # See available tags https://hub.docker.com/r/sigp/lighthouse/tags.
 #LIGHTHOUSE_VERSION=
 
@@ -27,7 +27,7 @@
 
 # Checkpoint sync url used by lighthouse to fast sync.
 # See available options https://eth-clients.github.io/checkpoint-sync-endpoints/.
-#LIGHTHOUSE_CHECKPOINT_SYNC_URL=
+LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 ######### Lodestar Config #########
 
@@ -74,8 +74,8 @@
 #MEVBOOST_VERSION=
 
 # Comma separated list of MEV-Boost relays.
-# You can choose public relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
-#MEVBOOST_RELAYS=
+# You can choose public mainnet relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
+MEVBOOST_RELAYS=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
 
 ######### Monitoring Config #########
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.13.4}
+    image: ethereum/client-go:${GETH_VERSION:-v1.13.5}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
@@ -104,7 +104,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|  
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.11.3}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.12.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]
@@ -124,7 +124,7 @@ services:
   #  | | | | | |  __/\ V /_____| |_) | (_) | (_) \__ \ |_
   #  |_| |_| |_|\___| \_/      |_.__/ \___/ \___/|___/\__|
   mev-boost:
-    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.5.0}
+    image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.6}
     networks: [dvnode]
     command: |
       -${NETWORK:-goerli} 


### PR DESCRIPTION
Add `.env.sample.mainnet` file to make this repo mainnet-ready in preparation for beta launch.

For users to run CDVN on mainnet, they need to copy .env.sample.mainnet: `cp -n .env.sample.mainnet .env`. We need to update the docs https://docs.obol.tech/docs/int/quickstart/quickstart-mainnet to reflect this.

ticket: #235 