### PR TITLE
add secondary urls

### DIFF
--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -27,7 +27,7 @@ NETWORK=mainnet
 
 # Checkpoint sync url used by lighthouse to fast sync.
 # See available options https://eth-clients.github.io/checkpoint-sync-endpoints/.
-LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
+LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/,https://sync-mainnet.beaconcha.in/
 
 ######### Lodestar Config #########
 
@@ -75,8 +75,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 # Comma separated list of MEV-Boost relays.
 # You can choose public mainnet relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
-MEVBOOST_RELAYS=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net
-
+MEVBOOST_RELAYS=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net
 ######### Monitoring Config #########
 
 # Grafana docker container image version, e.g. `latest` or `9.4.3`.

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -27,7 +27,8 @@ NETWORK=mainnet
 
 # Checkpoint sync url used by lighthouse to fast sync.
 # See available options https://eth-clients.github.io/checkpoint-sync-endpoints/.
-LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/,https://sync-mainnet.beaconcha.in/
+# If the given url errors, try replacing it with an alternative url like https://sync-mainnet.beaconcha.in/.
+LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 ######### Lodestar Config #########
 


### PR DESCRIPTION
Add secondary mevboost relay to `.env.sample.mainnet`.

ticket: #235 