### PR TITLE
lighthouse validator import was missing datadir

### DIFF
--- a/examples/lighthouse/run.sh
+++ b/examples/lighthouse/run.sh
@@ -17,6 +17,7 @@ for f in /opt/charon/validator_keys/keystore-*.json; do
   lighthouse --network "${NETWORK}" account validator import \
     --reuse-password \
     --keystore "${f}" \
+    --datadir="/opt/data" \
     --password-file "${f//json/txt}"
 done
 


### PR DESCRIPTION
I wasn't able to get the lighthouse VC running without the datadir here.