### PR TITLE
add stop_grace_period to geth

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.13.5`.
+# Geth docker container image version, e.g. `latest` or `v1.13.8`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -9,7 +9,7 @@ NETWORK=mainnet
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.13.5`.
+# Geth docker container image version, e.g. `latest` or `v1.13.8`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.13.5}
+    image: ethereum/client-go:${GETH_VERSION:-v1.13.8}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
@@ -32,6 +32,7 @@ services:
       --metrics.addr=0.0.0.0
       --metrics.port=6060
     networks: [dvnode]
+    stop_grace_period: 2m
     volumes:
       - ./data/geth:/root/.ethereum
       - ./jwt:/root/jwt


### PR DESCRIPTION
Set `stop_grace_period` as 2 min for geth container.

This came from a great feedback that geth always takes a while to shutdown and ends up being killed by docker (default grace period is 10 sec). If `stop_grace_period` is not supplied, the recent blocks may get lost and the node gets out of sync.

ticket: none
category: feature