### PR TITLE
update clients for dencun on holesky

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -9,7 +9,7 @@
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.13.9`.
+# Geth docker container image version, e.g. `latest` or `v1.13.11`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 
@@ -31,7 +31,7 @@
 
 ######### Lodestar Config #########
 
-# Lodestar validator client docker container image version, e.g. `latest` or `v1.14.0`.
+# Lodestar validator client docker container image version, e.g. `latest` or `v1.15.0-rc.0`.
 # See available tags https://hub.docker.com/r/chainsafe/lodestar/tags
 #LODESTAR_VERSION=
 

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -9,7 +9,7 @@ NETWORK=mainnet
 
 ######### Geth Config #########
 
-# Geth docker container image version, e.g. `latest` or `v1.13.8`.
+# Geth docker container image version, e.g. `latest` or `v1.13.11`.
 # See available tags https://hub.docker.com/r/ethereum/client-go/tags
 #GETH_VERSION=
 
@@ -32,7 +32,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 ######### Lodestar Config #########
 
-# Lodestar validator client docker container image version, e.g. `latest` or `v1.8.0`.
+# Lodestar validator client docker container image version, e.g. `latest` or `v1.15.0-rc.0`.
 # See available tags https://hub.docker.com/r/chainsafe/lodestar/tags
 #LODESTAR_VERSION=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,7 @@ services:
   #  |___/
 
   geth:
-    image: ethereum/client-go:${GETH_VERSION:-v1.13.9}
+    image: ethereum/client-go:${GETH_VERSION:-v1.13.11}
     ports:
       - ${GETH_PORT_P2P:-30303}:30303/tcp # P2P TCP
       - ${GETH_PORT_P2P:-30303}:30303/udp # P2P UDP
@@ -46,7 +46,7 @@ services:
   #      |___/
 
   lighthouse:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0-rc.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.6.0}
     ports:
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/tcp   # P2P TCP
       - ${LIGHTHOUSE_PORT_P2P:-9000}:9000/udp   # P2P UDP
@@ -105,7 +105,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|  
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.14.0-rc.1}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.15.0-rc.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
Update clients to support upcoming dencun fork on sepolia and holesky testnets.

https://blog.ethereum.org/2024/01/24/sepolia-holesky-dencun