### PR TITLE
Speed up Lodestar keystore import

### DIFF
--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -37,7 +37,7 @@ for f in /home/charon/validator_keys/keystore-*.json; do
     install -m 600 "$f" "${PUBKEY_DIR}/voting-keystore.json"
 
     # Copy the corresponding password file
-    PASSWORD_FILE="${f//json/txt}"
+    PASSWORD_FILE="${f%.json}.txt"
     install -m 600 "${PASSWORD_FILE}" "${SECRETS_DIR}/${PUBKEY}"
 
     IMPORTED_COUNT=$((IMPORTED_COUNT + 1))

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -8,21 +8,47 @@ then
   BUILDER_SELECTION="builderonly"
 fi
 
+DATA_DIR="/opt/data"
+KEYSTORES_DIR="${DATA_DIR}/keystores"
+SECRETS_DIR="${DATA_DIR}/secrets"
+
+mkdir -p "${KEYSTORES_DIR}" "${SECRETS_DIR}"
+
+IMPORTED_COUNT=0
+EXISTING_COUNT=0
+
 for f in /home/charon/validator_keys/keystore-*.json; do
     echo "Importing key ${f}"
 
-    # Import keystore with password.
-    node /usr/app/packages/cli/bin/lodestar validator import \
-        --dataDir="/opt/data" \
-        --network="$NETWORK" \
-        --importKeystores="$f" \
-        --importKeystoresPassword="${f//json/txt}"
+    # Extract pubkey from keystore file
+    PUBKEY=$(grep '"pubkey"' "$f" | awk -F'"' '{print $4}')
+
+    PUBKEY_DIR="${KEYSTORES_DIR}/${PUBKEY}"
+
+    # Skip import if keystore already exists
+    if [ -d "${PUBKEY_DIR}" ]; then
+        EXISTING_COUNT=$((EXISTING_COUNT + 1))
+        continue
+    fi
+
+    mkdir -p "${PUBKEY_DIR}"
+
+    # Copy the keystore file to persisted keys backend
+    install -m 600 "$f" "${PUBKEY_DIR}/voting-keystore.json"
+
+    # Copy the corresponding password file
+    PASSWORD_FILE="${f//json/txt}"
+    install -m 600 "${PASSWORD_FILE}" "${SECRETS_DIR}/${PUBKEY}"
+
+    IMPORTED_COUNT=$((IMPORTED_COUNT + 1))
 done
 
-echo "Imported all keys"
+echo "Processed all keys imported=${IMPORTED_COUNT}, existing=${EXISTING_COUNT}, total=$(ls /home/charon/validator_keys/keystore-*.json | wc -l)"
 
 exec node /usr/app/packages/cli/bin/lodestar validator \
-    --dataDir="/opt/data" \
+    --dataDir="$DATA_DIR" \
+    --keystoresDir="$KEYSTORES_DIR" \
+    --secretsDir="$SECRETS_DIR" \
     --network="$NETWORK" \
     --metrics=true \
     --metrics.address="0.0.0.0" \

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -21,7 +21,7 @@ for f in /home/charon/validator_keys/keystore-*.json; do
     echo "Importing key ${f}"
 
     # Extract pubkey from keystore file
-    PUBKEY=$(grep '"pubkey"' "$f" | awk -F'"' '{print $4}')
+    PUBKEY="0x$(grep '"pubkey"' "$f" | awk -F'"' '{print $4}')"
 
     PUBKEY_DIR="${KEYSTORES_DIR}/${PUBKEY}"
 


### PR DESCRIPTION
Lodestar does not natively support importing keystores with different password in an efficient way right now (see https://github.com/ChainSafe/lodestar/issues/5249) that's why each keystore is imported individually right now via `validator import` command, but this is really slow, and redundant if keystores already exist after first startup.

We can speed this up significantly by directly writing keystores in Lodestar persistent keys backend, the outcome is exactly the same, we skip keys that are already imported, and put them into `keystoresDir` and `secretsDir` of Lodestar in the expected format.

This is the approach described in [protolambda/eth2-val-tools](https://github.com/protolambda/eth2-val-tools?tab=readme-ov-file#lodestar) and there is no downside in doing it like this.

It could further be considered if we wanna remove keystores from the persistent keys backend if those are no longer part of `charon/validator_keys` directory but this was not done previously as well and can be implemented separately if desired.