### PR TITLE
charon and lighthouse_vc fixes

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -4,7 +4,7 @@
 # Overrides network for all the relevant services.
 #NETWORK=
 
-# Enables builder api for lodestar VC and charon services.
+# Enables builder api for VC and charon services.
 #BUILDER_API_ENABLED=
 
 ######### Nethermind Config #########

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -4,7 +4,7 @@
 # Overrides network for all the relevant services.
 NETWORK=mainnet
 
-# Enables builder api for lodestar VC and charon services.
+# Enables builder api for VC and charon services.
 #BUILDER_API_ENABLED=
 
 ######### Nethermind Config #########
@@ -78,7 +78,7 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 
 # Comma separated list of MEV-Boost relays.
 # You can choose public mainnet relays from https://enchanted-direction-844.notion.site/6d369eb33f664487800b0dedfe32171e?v=d255247c822c409f99c498aeb6a4e51d.
-MEVBOOST_RELAYS=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net
+#MEVBOOST_RELAYS=https://0xac6e77dfe25ecd6110b8e780608cce0dab71fdd5ebea22a16c0205200f2f8e2e3ad3b71d3499c54ad14d6c21b41a37ae@boost-relay.flashbots.net,https://0xa7ab7a996c8584251c8f925da3170bdfd6ebc75d50f5ddc4050a6fdc77f2a3b5fce2cc750d0865e05d7228af97d69561@agnostic-relay.net
 ######### Monitoring Config #########
 
 # Grafana docker container image version, e.g. `latest` or `9.4.3`.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Please exercise caution when using them and ensure that you thoroughly review an
 To run any of the examples, use the following command:
 
 ```
-docker compose -f examples/nethermind_teku_lighthouse.yml up
+docker compose --env-file ./.env -f examples/geth_teku_lighthouse.yml up
 ```
 
 

--- a/examples/geth_teku_lighthouse.yml
+++ b/examples/geth_teku_lighthouse.yml
@@ -47,7 +47,7 @@ services:
     image: flashbots/mev-boost:${MEVBOOST_VERSION:-1.5.0}
     networks: [dvnode]
     command: |
-      -${NETWORK:-holesky} 
+      -${NETWORK:-holesky}
       -loglevel=debug
       -addr=0.0.0.0:18550
       -relay-check
@@ -93,7 +93,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v0.15.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.1}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://teku_bn:4000}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
@@ -103,7 +103,7 @@ services:
       - CHARON_P2P_TCP_ADDRESS=0.0.0.0:${CHARON_PORT_P2P_TCP:-3610}
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600
       - CHARON_MONITORING_ADDRESS=0.0.0.0:3620
-      - BUILDER_API_ENABLED=${BUILDER_API_ENABLED:-false}
+      - CHARON_BUILDER_API=${BUILDER_API_ENABLED:-false}
     ports:
       - ${CHARON_PORT_P2P_TCP:-3610}:${CHARON_PORT_P2P_TCP:-3610}/tcp # P2P TCP libp2p
     networks: [dvnode]
@@ -121,7 +121,7 @@ services:
   #      |___/
 
   lighthouse_vc:
-    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v4.2.0}
+    image: sigp/lighthouse:${LIGHTHOUSE_VERSION:-v5.3.0}
     entrypoint: /opt/lighthouse/run.sh
     networks: [dvnode]
     depends_on: [ charon ]

--- a/examples/lighthouse/run.sh
+++ b/examples/lighthouse/run.sh
@@ -31,4 +31,5 @@ exec lighthouse --network "${NETWORK}" validator \
   --metrics-port "5064" \
   --use-long-timeouts \
   --datadir="/opt/data" \
-  --builder-proposals=$BUILDER_API_ENABLED
+  --distributed \
+  $( [ "$BUILDER_API_ENABLED" = "true" ] && echo "--builder-proposals" )


### PR DESCRIPTION
This PR fixes a couple of errors encountered when trying to use the geth_teku_lighthouse example.

1 - lighthouse validator was failing to start with error:  "lighthouse_vc-1  | error: unexpected value 'true' for '--builder-proposals' found; no more were expected"
Fix by modifying lighthouse/run.sh to check the value of the variable and add the --builder-proposals accordingly (without =true)

2 - charon was not receiving the BUILDER_API_ENABLED env variable properly.  Fix by using the proper variable name (as per [Lodestar example](https://github.com/ObolNetwork/charon-distributed-validator-node/blob/2cb55713b9c341a81c0757025919b35cd277de5a/docker-compose.yml#L87))

lighthouse validator also has a ['distributed' arg](https://github.com/sigp/lighthouse/blob/d6ba8c397557f5c977b70f0d822a9228e98ca214/validator_client/src/cli.rs#L179), which I also added because it looks to be required for use in a DV