### PR TITLE
Use POSIX-compliant syntax in Lodestar entrypoint script

### DIFF
--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -3,7 +3,7 @@
 BUILDER_SELECTION="executiononly"
 
 # If the builder API is enabled, override the builder selection to signal Lodestar to always propose blinded blocks.
-if [[ $BUILDER_API_ENABLED == "true" ]];
+if [ "$BUILDER_API_ENABLED" = "true" ];
 then
   BUILDER_SELECTION="builderonly"
 fi
@@ -16,7 +16,7 @@ for f in /home/charon/validator_keys/keystore-*.json; do
         --dataDir="/opt/data" \
         --network="$NETWORK" \
         --importKeystores="$f" \
-        --importKeystoresPassword="${f//json/txt}"
+        --importKeystoresPassword="${f%.json}.txt"
 done
 
 echo "Imported all keys"


### PR DESCRIPTION
We switched from alpine to debian in our latest release (v1.21.0). The current entrypoint script uses syntax which is not POSIX-compliant and the script will fail to execute.

```
Importing key /home/charon/validator_keys/keystore-0.json
/opt/lodestar/run.sh: 6: [[: not found
/opt/lodestar/run.sh: 15: Bad substitution
```

This change does not require to bump the Lodestar version the script will still work with older releases.