### PR TITLE
Bump charon to v1.0.1 in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -74,7 +74,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.0.1}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}


### PR DESCRIPTION
Bump charon to latest release which is now v1.0.1:
- https://github.com/ObolNetwork/charon/releases/tag/v1.0.1
- https://hub.docker.com/layers/obolnetwork/charon/v1.0.1/images/sha256-941893dd41ec0981244537028174e4857236d203a8741829a3b36d5cbcbdb221?context=explore