### PR TITLE
Bump default Lodestar version to 1.21.0

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -101,7 +101,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|  
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.19.0}
+    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.21.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
This release includes improvements related to fetching duties if node was previously syncing.