### PR TITLE
Misc changes to charon v1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,23 +21,30 @@ Check the Obol [docs](https://docs.obol.tech/docs/start/quickstart_overview) for
 
 A default example configuration of a full validator node is found in the root `docker-compose.yml` file.
 
-The `examples/` directory is under development, you will find a collection of docker compose configuration files that demonstrate various clients and their configurations for running a Distributed Validator Node. These files are with filenames as {EC}-{CC}-{VC}.yml (where EC: Execution Client, CC: Consensus Client, VC: Validator Client). For example, if you wish to run a DV node with Geth EL, Teku CL and Lighthouse VC, you can run `geth_teku_lighthouse.yml`.
+To customize your node configuration, you can create a `docker-compose.override.yml` file. A sample override file is provided as `docker-compose.override.yml.sample` which you can use as a starting point. This allows you to override default settings and choose different client combinations without modifying the base configuration.
 
 ⚠️⚠️⚠️ **Important:**
 The configurations provided are meant for demonstration purposes only and may not be suitable for production environments.
-These examples are primarily intended for advanced users who are familiar with Docker and have a good understanding of execution and consensus clients.
 Please exercise caution when using them and ensure that you thoroughly review and customize the configurations according to your specific requirements.
 
-To run the default example, use the following command:
+To run the default configuration, use the following command:
 
 ```sh
 docker compose up
 ```
 
-To run any of the other examples, found in `examples/` use the following command:
+To use a custom configuration with an override file:
 
+1. Copy the sample override file:
 ```sh
-docker compose -f examples/nethermind_teku_lighthouse.yml up
+cp docker-compose.override.yml.sample docker-compose.override.yml
+```
+
+2. Edit the `docker-compose.override.yml` file to suit your needs
+
+3. Run docker compose (it will automatically use both files):
+```sh
+docker compose up
 ```
 
 # FAQs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -77,7 +77,7 @@ services:
   #  \___|_| |_|\__,_|_|  \___/|_| |_|
 
   charon:
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.2.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.5.2}
     environment:
       - CHARON_BEACON_NODE_ENDPOINTS=${CHARON_BEACON_NODE_ENDPOINTS:-http://lighthouse:5052}
       - CHARON_BEACON_NODE_TIMEOUT=${CHARON_BEACON_NODE_TIMEOUT:-3s}

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 #
   relay:
     # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.1.1}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.2.0}
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_HTTP_ADDRESS: 0.0.0.0:3640

--- a/relay/docker-compose.yml
+++ b/relay/docker-compose.yml
@@ -6,7 +6,7 @@ services:
 #
   relay:
     # Pegged charon version (update this for each release).
-    image: obolnetwork/charon:${CHARON_VERSION:-v1.2.0}
+    image: obolnetwork/charon:${CHARON_VERSION:-v1.5.2}
     environment:
       CHARON_P2P_TCP_ADDRESS: 0.0.0.0:3610
       CHARON_HTTP_ADDRESS: 0.0.0.0:3640


### PR DESCRIPTION
This PR include the following changes:
- Bumps relay charon to v1.2
- Removed references to the non-existent `examples/` directory
- Added instructions for using `docker-compose.override.yml.sample`
- Provided step-by-step guidance for creating and using custom configurations