### PR TITLE
Remove run.sh entrypoint for Prometheus

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -156,7 +156,6 @@ services:
     volumes:
       - ./prometheus:/etc/prometheus
       - ./data/prometheus:/prometheus
-    entrypoint: /etc/prometheus/run.sh
     restart: unless-stopped
 
   grafana:


### PR DESCRIPTION
When running multiple DVnodes, it can be easy to integrate them into a single prometheus job like this:

```
  - job_name: charon
    static_configs:
      - targets: [charon:20120,charon:20220]
    static_configs:
      - targets: [lodestar:20164,lodestar:20264]
  - job_name: lodestar
```

However with the entrypoint for run.sh, these changes get overwritten whenever the container relaunches. Lido already has this removed from their fork by default - and I think it makes sense to make it easier to make adjustments to prometheus.yml by default.