### PR TITLE
Replaced jaeger with tempo and OTLP

### DIFF
--- a/.env.sample.holesky
+++ b/.env.sample.holesky
@@ -127,12 +127,10 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.holesky.ethpandaops.io/
 # See available tags https://hub.docker.com/r/bitnami/node-exporter/tags.
 #NODE_EXPORTER_VERSION=
 
-# Jaeger docker container image version, e.g. `latest` or `1.46.0`.
-# See available tags https://hub.docker.com/r/jaegertracing/all-in-one/tags.
-#JAEGER_VERSION=
-
-# Jaeger host exposed port for HTTP query.
-#MONITORING_PORT_JAEGER=
+# Grafana Tempo docker container image version, e.g. `latest` or `2.7.1`.
+# Use Grafana Explore to access Tempo data.
+# See available tags https://hub.docker.com/r/grafana/tempo/tags.
+#TEMPO_VERSION=
 
 # Grafana Loki docker container image version, e.g. `latest` or `2.8.2`.
 # See available tags https://hub.docker.com/r/grafana/loki/tags.

--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -127,12 +127,10 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.hoodi.ethpandaops.io/
 # See available tags https://hub.docker.com/r/bitnami/node-exporter/tags.
 #NODE_EXPORTER_VERSION=
 
-# Jaeger docker container image version, e.g. `latest` or `1.46.0`.
-# See available tags https://hub.docker.com/r/jaegertracing/all-in-one/tags.
-#JAEGER_VERSION=
-
-# Jaeger host exposed port for HTTP query.
-#MONITORING_PORT_JAEGER=
+# Grafana Tempo docker container image version, e.g. `latest` or `2.7.1`.
+# Use Grafana Explore to access Tempo data.
+# See available tags https://hub.docker.com/r/grafana/tempo/tags.
+#TEMPO_VERSION=
 
 # Grafana Loki docker container image version, e.g. `latest` or `2.8.2`.
 # See available tags https://hub.docker.com/r/grafana/loki/tags.

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -127,12 +127,10 @@ MEVBOOST_RELAYS=https://0xa15b52576bcbf1072f4a011c0f99f9fb6c66f3e1ff321f11f461d1
 # See available tags https://hub.docker.com/r/bitnami/node-exporter/tags.
 #NODE_EXPORTER_VERSION=
 
-# Jaeger docker container image version, e.g. `latest` or `1.46.0`.
-# See available tags https://hub.docker.com/r/jaegertracing/all-in-one/tags.
-#JAEGER_VERSION=
-
-# Jaeger host exposed port for HTTP query.
-#MONITORING_PORT_JAEGER=
+# Grafana Tempo docker container image version, e.g. `latest` or `2.7.1`.
+# Use Grafana Explore to access Tempo data.
+# See available tags https://hub.docker.com/r/grafana/tempo/tags.
+#TEMPO_VERSION=
 
 # Grafana Loki docker container image version, e.g. `latest` or `2.8.2`.
 # See available tags https://hub.docker.com/r/grafana/loki/tags.

--- a/compose-debug.yml
+++ b/compose-debug.yml
@@ -23,18 +23,14 @@ services:
   node-exporter:
     image: bitnami/node-exporter:${NODE_EXPORTER_VERSION:-1.6.0}
 
-  jaeger:
-    image: jaegertracing/all-in-one:${JAEGER_VERSION:-1.46.0}
-    ports:
-      - ${MONITORING_PORT_JAEGER:-16686}:16686
-    environment:
-      - SPAN_STORAGE_TYPE=badger
-      - BADGER_EPHEMERAL=false
-      - BADGER_DIRECTORY_VALUE=/badger/data
-      - BADGER_DIRECTORY_KEY=/badger/key
-      - BADGER_SPAN_STORE_TTL=72h
+  tempo:
+    image: grafana/tempo:${TEMPO_VERSION:-2.7.1}
+    user: ":"
+    command: -config.file=/etc/tempo/tempo.yaml
     volumes:
-      - ./data/jaeger:/badger
+      - ./tempo:/etc/tempo
+      - ./data/tempo:/opt/tempo
+    restart: unless-stopped
 
   loki:
     image: grafana/loki:${LOKI_VERSION:-2.8.2}
@@ -47,8 +43,8 @@ services:
 
   charon:
     environment:
-      - CHARON_JAEGER_ADDRESS=jaeger:6831 # jaeger UDP agent
-      - CHARON_JAEGER_SERVICE=charon
+      - CHARON_OTLP_ADDRESS=tempo:4317
+      - CHARON_OTLP_SERVICE_NAME=charon
       - CHARON_LOKI_ADDRESSES=${CHARON_LOKI_ADDRESSES:-http://loki:3100/loki/api/v1/push}
       - CHARON_LOKI_SERVICE=charon
 

--- a/grafana/datasource.yml
+++ b/grafana/datasource.yml
@@ -31,3 +31,13 @@ datasources:
     isDefault: false
     version: 1
     editable: true
+
+  - name: Tempo
+    type: tempo
+    uid: tempo
+    orgId: 1
+    url: http://tempo:3200
+    basicAuth: false
+    isDefault: false
+    version: 1
+    editable: true

--- a/tempo/tempo.yaml
+++ b/tempo/tempo.yaml
@@ -1,0 +1,25 @@
+server:
+  http_listen_port: 3200
+  grpc_listen_port: 9095
+
+distributor:
+  receivers:
+    otlp:
+      protocols:
+        grpc:
+          endpoint: 0.0.0.0:4317
+
+ingester:
+  trace_idle_period: 10s
+  max_block_bytes: 1_048_576
+  max_block_duration: 5m
+
+compactor:
+  compaction:
+    block_retention: 24h
+
+storage:
+  trace:
+    backend: local
+    local:
+      path: /opt/tempo/traces


### PR DESCRIPTION
For charon v1.4.x:

- Removed jaeger setup.
- Added tempo setup with OTLP settings.

Same settings were tested with kurtosis-charon.