### PR TITLE
Allow a user to turn on a modified lodestar image with more aggressive timeouts

### DIFF
--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -45,6 +45,9 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 # See available tags https://hub.docker.com/r/chainsafe/lodestar/tags
 #LODESTAR_VERSION=
 
+# If you uncomment this you must also set LODESTAR_VERSION=obol-workaround
+#LODESTAR_IMAGE=ethpandaops/lodestar
+
 # Override prometheus metrics port for lodestar validator client.
 #LODESTAR_PORT_METRICS=
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -119,7 +119,7 @@ services:
   # |_|\___/ \__,_|\___||___/\__\__,_|_|
 
   lodestar:
-    image: chainsafe/lodestar:${LODESTAR_VERSION:-v1.29.0}
+    image: ${LODESTAR_IMAGE:-chainsafe/lodestar}:${LODESTAR_VERSION:-v1.29.0}
     depends_on: [charon]
     entrypoint: /opt/lodestar/run.sh
     networks: [dvnode]


### PR DESCRIPTION
Some CDVN users are experiencing hangs when their cluster has two aggregators on different committees in the same slot. This causes issues as lodestar decides to skip the next slot entirely if aggregations hang past the 4 second mark. 

Lodestar have released a modified image which timeouts after two seconds, which should mitigate this occurrence for the time being. 

This PR allows a user to uncomment the LODESTAR_IMAGE env var, while setting LODESTAR_VERSION=obol-workaround. This will swap the standard lodestar image to this modified build, and should mitigate these skipped slots. 