### PR TITLE
Fix issue in run.sh that block sending monitoring data.

### DIFF
--- a/prometheus/run.sh
+++ b/prometheus/run.sh
@@ -11,8 +11,8 @@ then
   exit 1
 fi
 
-
-sed "s|\$PROM_REMOTE_WRITE_TOKEN|${PROM_REMOTE_WRITE_TOKEN}|g" \
+sed -e "s|\${PROM_REMOTE_WRITE_TOKEN}|${PROM_REMOTE_WRITE_TOKEN}|g" \
+    -e "s|\${SERVICE_OWNER}|${SERVICE_OWNER}|g" \
     /etc/prometheus/prometheus.yml.example > /etc/prometheus/prometheus.yml
 
 /bin/prometheus \


### PR DESCRIPTION
There is a bug in the prometheus/run.sh

**The sed command is incorrect:**
sed "s|\$PROM_REMOTE_WRITE_TOKEN|${PROM_REMOTE_WRITE_TOKEN}|g" \
    /etc/prometheus/prometheus.yml.example > /etc/prometheus/prometheus.yml

**Because of this we have 401 errors:**
time=2025-05-15T17:44:14.111Z level=ERROR source=queue_manager.go:570 msg="non-recoverable error while sending metadata" component=remote remote_name=fb11d2 url=https://vm.monitoring.gcp.obol.tech/write count=839 err="server returned HTTP status 401 Unauthorized: Unauthorized\n"

**The right comand is:**
sed -e "s|\${PROM_REMOTE_WRITE_TOKEN}|${PROM_REMOTE_WRITE_TOKEN}|g" \
    -e "s|\${SERVICE_OWNER}|${SERVICE_OWNER}|g" \
    /etc/prometheus/prometheus.yml.example > /etc/prometheus/prometheus.yml

And after fix data are sending correctly