### PR TITLE
Add automated scripts for Charon replace-operator ceremony

### DIFF
--- a/scripts/edit/README.md
+++ b/scripts/edit/README.md
@@ -1,0 +1,165 @@
+# Cluster Edit Automation Scripts
+
+This directory contains automation scripts to help node operators perform cluster editing operations for Charon distributed validators. The scripts currently support the **replace-operator** ceremony.
+
+## Directory Structure
+
+```
+scripts/edit/
+├── lib/
+│   └── update-anti-slashing-db.sh    # Library script for ASDB key translation
+└── <vc_type>/                         # VC-specific scripts (e.g., lodestar/)
+    ├── export_asdb.sh                 # Export anti-slashing database
+    ├── import_asdb.sh                 # Import anti-slashing database
+    └── replace_operator.sh            # Main orchestration script
+```
+
+## Prerequisites
+
+Before using these scripts, ensure:
+
+1. **Environment Configuration**: Your `.env` file must exist and contain:
+   - `NETWORK` - The Ethereum network (e.g., `mainnet`, `hoodi`, `sepolia`)
+
+2. **Validator Client Profile**: You must be using the `vc-lodestar` profile:
+   - Set `VC=vc-lodestar` in your `.env` file
+   - Ensure the profile is active in your docker compose setup
+
+3. **Required Tools**:
+   - `docker` and `docker compose`
+   - `jq` - JSON processor
+   - `zip` - For creating backups
+
+4. **Directory Structure**: Run scripts from the repository root where:
+   - `.charon/` directory exists
+   - `docker-compose.yml` is present
+
+## Replace-Operator Workflow
+
+The replace-operator ceremony allows a cluster to swap one operator for another without changing validator public keys. This requires coordination between all continuing operators and the new operator.
+
+### For Continuing Operators
+
+Continuing operators are existing cluster members who will remain in the cluster after the replacement.
+
+#### CLI Mode
+
+```bash
+./scripts/edit/lodestar/replace_operator.sh \
+  --role continuing \
+  --old-enr enr:-JG4QH... \
+  --new-enr enr:-JG4QK...
+```
+
+#### Interactive Mode
+
+```bash
+./scripts/edit/lodestar/replace_operator.sh
+```
+
+The script will prompt for:
+- Your role (select "continuing")
+- Old operator ENR
+- New operator ENR
+
+#### What Happens
+
+1. **Backup**: Creates `.charon-before-replace-operator-TIMESTAMP.zip`
+2. **Export ASDB**: Prompts you to run `./scripts/edit/lodestar/export_asdb.sh`
+3. **Ceremony**: Executes the replace-operator ceremony with other operators
+4. **Update ASDB**: Translates validator keys in the exported database
+5. **Instructions**: Displays steps to activate the new configuration
+
+### For New Operators
+
+New operators are joining the cluster to replace an existing operator.
+
+#### CLI Mode
+
+```bash
+./scripts/edit/lodestar/replace_operator.sh \
+  --role new \
+  --old-enr enr:-JG4QH... \
+  --new-enr enr:-JG4QK... \
+  --cluster-lock-file ./cluster-lock.json
+```
+
+#### Interactive Mode
+
+```bash
+./scripts/edit/lodestar/replace_operator.sh
+```
+
+The script will prompt for:
+- Your role (select "new")
+- Old operator ENR
+- New operator ENR  
+- Path to your `cluster-lock.json` file
+
+#### What Happens
+
+1. **Backup**: Creates `.charon-before-replace-operator-TIMESTAMP.zip`
+2. **Ceremony**: Executes the replace-operator ceremony with other operators
+3. **Instructions**: Displays steps to activate the new configuration
+
+**Note**: New operators do NOT export/import anti-slashing databases since they start fresh.
+
+## Individual Script Usage
+
+While `replace_operator.sh` orchestrates the full workflow, you can also run individual scripts:
+
+### Export Anti-Slashing Database
+
+```bash
+./scripts/edit/lodestar/export_asdb.sh [--data-dir ./data/lodestar] [--output-file ./asdb-export/slashing-protection.json]
+```
+
+**Requirements**:
+- vc-lodestar container must be running
+- `.env` file with `NETWORK` variable
+
+**Output**: EIP-3076 format JSON file containing slashing protection data
+
+### Import Anti-Slashing Database
+
+```bash
+./scripts/edit/lodestar/import_asdb.sh [--input-file ./asdb-export/slashing-protection.json] [--data-dir ./data/lodestar]
+```
+
+**Requirements**:
+- vc-lodestar container must be STOPPED
+- Valid EIP-3076 JSON file
+- `.env` file with `NETWORK` variable
+
+**Effect**: Imports slashing protection data into Lodestar validator client
+
+### Ceremony timeout or failure
+
+If the ceremony fails or times out:
+
+1. **Check coordination**: Ensure all operators executed simultaneously
+2. **Check network**: Verify all operators can reach ceremony relays
+3. **Check ENRs**: Confirm old and new operator ENRs are correct
+4. **Rollback**: Restore from backup if needed:
+   ```bash
+   rm -rf .charon
+   unzip .charon-before-replace-operator-*.zip
+   rm -rf ./output
+   ```
+
+## Additional Resources
+
+- [Obol Replace-Operator Documentation](https://docs.obol.org/next/advanced-and-troubleshooting/advanced/replace-operator)
+- [Charon Edit Commands](https://docs.obol.org/next/advanced-and-troubleshooting/advanced/)
+- [EIP-3076 Slashing Protection Interchange Format](https://eips.ethereum.org/EIPS/eip-3076)
+
+## Future VC Support
+
+To add support for other validator clients (Nimbus, Prysm, Teku):
+
+1. Create a new directory: `scripts/edit/<vc_type>/`
+2. Implement `export_asdb.sh` for the client's slashing protection format
+3. Implement `import_asdb.sh` for the client's import mechanism
+4. Copy and adapt `replace_operator.sh` for the client's service name
+5. Update this README with client-specific instructions
+

--- a/scripts/edit/lib/update-anti-slashing-db.sh
+++ b/scripts/edit/lib/update-anti-slashing-db.sh
@@ -3,12 +3,17 @@
 # Script to update EIP-3076 anti-slashing DB by replacing pubkey values
 # based on lookup in source and target cluster-lock.json files.
 #
+# This script is invoked by replace_operator.sh for continuing operators only,
+# after the ceremony completes successfully. It translates validator pubkeys in
+# the exported anti-slashing database from old operator keys to new operator keys
+# using the source (original) and target (new) cluster-lock.json files.
+#
 # Usage: update-anti-slashing-db.sh <eip3076-file> <source-cluster-lock> <target-cluster-lock>
 #
 # Arguments:
 #   eip3076-file          - Path to EIP-3076 JSON file to update in place
-#   source-cluster-lock   - Path to source cluster-lock.json
-#   target-cluster-lock   - Path to target cluster-lock.json
+#   source-cluster-lock   - Path to source cluster-lock.json (original)
+#   target-cluster-lock   - Path to target cluster-lock.json (new, from output/)
 #
 # The script traverses the EIP-3076 JSON file and finds all "pubkey" values in the
 # data array. For each pubkey, it looks up the value in the source cluster-lock.json's
@@ -158,7 +163,7 @@ if [ -z "$pubkeys" ]; then
     exit 0
 fi
 
-pubkey_count=$(echo "$pubkeys" | wc -l | xargs)
+pubkey_count=$(grep -c '^' <<< "$pubkeys")
 echo "Found $pubkey_count unique pubkey(s) to process"
 echo ""
 

--- a/scripts/edit/lodestar/export_asdb.sh
+++ b/scripts/edit/lodestar/export_asdb.sh
@@ -1,0 +1,111 @@
+#!/usr/bin/env bash
+
+# Script to export Lodestar validator anti-slashing database to EIP-3076 format.
+#
+# This script is run by continuing operators before the replace-operator ceremony.
+# It exports the slashing protection database from the running vc-lodestar container
+# to a JSON file that can be updated and re-imported after the ceremony.
+#
+# Usage: export_asdb.sh [--data-dir <path>] [--output-file <path>]
+#
+# Options:
+#   --data-dir      Path to Lodestar data directory (default: ./data/lodestar)
+#   --output-file   Path for exported slashing protection JSON (default: ./asdb-export/slashing-protection.json)
+#
+# Requirements:
+#   - .env file must exist with NETWORK variable set
+#   - vc-lodestar container must be running
+#   - docker and docker compose must be available
+
+set -euo pipefail
+
+# Default values
+DATA_DIR="./data/lodestar"
+OUTPUT_FILE="./asdb-export/slashing-protection.json"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --data-dir)
+            DATA_DIR="$2"
+            shift 2
+            ;;
+        --output-file)
+            OUTPUT_FILE="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            echo "Usage: $0 [--data-dir <path>] [--output-file <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "Error: .env file not found in current directory" >&2
+    echo "Please ensure you are running this script from the repository root" >&2
+    exit 1
+fi
+
+# Source .env to get NETWORK
+source .env
+
+# Check if NETWORK is set
+if [ -z "${NETWORK:-}" ]; then
+    echo "Error: NETWORK variable not set in .env file" >&2
+    echo "Please set NETWORK (e.g., mainnet, hoodi, sepolia) in your .env file" >&2
+    exit 1
+fi
+
+echo "Exporting anti-slashing database for Lodestar validator client"
+echo "Network: $NETWORK"
+echo "Data directory: $DATA_DIR"
+echo "Output file: $OUTPUT_FILE"
+echo ""
+
+# Check if vc-lodestar container is running
+if ! docker compose ps vc-lodestar | grep -q Up; then
+    echo "Error: vc-lodestar container is not running" >&2
+    echo "Please start the validator client before exporting:" >&2
+    echo "  docker compose up -d vc-lodestar" >&2
+    exit 1
+fi
+
+# Create output directory if it doesn't exist
+OUTPUT_DIR=$(dirname "$OUTPUT_FILE")
+mkdir -p "$OUTPUT_DIR"
+
+echo "Exporting slashing protection data from vc-lodestar container..."
+
+# Export slashing protection data from the container
+# The container writes to /tmp/export.json, then we copy it out
+# Using full path to lodestar binary as found in run.sh to ensure it's found
+if ! docker compose exec -T vc-lodestar node /usr/app/packages/cli/bin/lodestar validator slashing-protection export \
+    --file /tmp/export.json \
+    --dataDir /opt/data \
+    --network "$NETWORK"; then
+    echo "Error: Failed to export slashing protection from vc-lodestar container" >&2
+    exit 1
+fi
+
+echo "Copying exported file from container to host..."
+
+# Copy the exported file from container to host
+if ! docker compose cp vc-lodestar:/tmp/export.json "$OUTPUT_FILE"; then
+    echo "Error: Failed to copy exported file from container" >&2
+    exit 1
+fi
+
+# Validate the exported JSON
+if ! jq empty "$OUTPUT_FILE" 2>/dev/null; then
+    echo "Error: Exported file is not valid JSON" >&2
+    exit 1
+fi
+
+echo ""
+echo "✓ Successfully exported anti-slashing database"
+echo "  Output file: $OUTPUT_FILE"
+echo ""
+echo "You can now proceed with the replace-operator ceremony."

--- a/scripts/edit/lodestar/import_asdb.sh
+++ b/scripts/edit/lodestar/import_asdb.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+
+# Script to import Lodestar validator anti-slashing database from EIP-3076 format.
+#
+# This script is run by continuing operators after the replace-operator ceremony
+# and anti-slashing database update. It imports the updated slashing protection
+# database back into the vc-lodestar container.
+#
+# Usage: import_asdb.sh [--input-file <path>] [--data-dir <path>]
+#
+# Options:
+#   --input-file    Path to updated slashing protection JSON (default: ./asdb-export/slashing-protection.json)
+#   --data-dir      Path to Lodestar data directory (default: ./data/lodestar)
+#
+# Requirements:
+#   - .env file must exist with NETWORK variable set
+#   - vc-lodestar container must be STOPPED before import
+#   - docker and docker compose must be available
+#   - Input file must be valid EIP-3076 JSON
+
+set -euo pipefail
+
+# Default values
+INPUT_FILE="./asdb-export/slashing-protection.json"
+DATA_DIR="./data/lodestar"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --input-file)
+            INPUT_FILE="$2"
+            shift 2
+            ;;
+        --data-dir)
+            DATA_DIR="$2"
+            shift 2
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            echo "Usage: $0 [--input-file <path>] [--data-dir <path>]" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Check if .env file exists
+if [ ! -f .env ]; then
+    echo "Error: .env file not found in current directory" >&2
+    echo "Please ensure you are running this script from the repository root" >&2
+    exit 1
+fi
+
+# Source .env to get NETWORK
+source .env
+
+# Check if NETWORK is set
+if [ -z "${NETWORK:-}" ]; then
+    echo "Error: NETWORK variable not set in .env file" >&2
+    echo "Please set NETWORK (e.g., mainnet, hoodi, sepolia) in your .env file" >&2
+    exit 1
+fi
+
+echo "Importing anti-slashing database for Lodestar validator client"
+echo "Network: $NETWORK"
+echo "Data directory: $DATA_DIR"
+echo "Input file: $INPUT_FILE"
+echo ""
+
+# Check if input file exists
+if [ ! -f "$INPUT_FILE" ]; then
+    echo "Error: Input file not found: $INPUT_FILE" >&2
+    exit 1
+fi
+
+# Validate input file is valid JSON
+if ! jq empty "$INPUT_FILE" 2>/dev/null; then
+    echo "Error: Input file is not valid JSON: $INPUT_FILE" >&2
+    exit 1
+fi
+
+# Check if vc-lodestar container is running (it should be stopped)
+if docker compose ps vc-lodestar 2>/dev/null | grep -q Up; then
+    echo "Error: vc-lodestar container is still running" >&2
+    echo "Please stop the validator client before importing:" >&2
+    echo "  docker compose stop vc-lodestar" >&2
+    echo "" >&2
+    echo "Importing while the container is running may cause database corruption." >&2
+    exit 1
+fi
+
+echo "Importing slashing protection data into vc-lodestar container..."
+
+# Import slashing protection data using a temporary container based on the vc-lodestar service.
+# The input file is bind-mounted into the container at /tmp/import.json (read-only).
+# We MUST override the entrypoint because the default run.sh ignores arguments.
+# Using --force to allow importing even if some data already exists.
+if ! docker compose run --rm -T \
+    --entrypoint node \
+    -v "$INPUT_FILE":/tmp/import.json:ro \
+    vc-lodestar /usr/app/packages/cli/bin/lodestar validator slashing-protection import \
+    --file /tmp/import.json \
+    --dataDir /opt/data \
+    --network "$NETWORK" \
+    --force; then
+    echo "Error: Failed to import slashing protection into vc-lodestar container" >&2
+    exit 1
+fi
+
+echo ""
+echo "✓ Successfully imported anti-slashing database"
+echo ""
+echo "You can now restart the validator client:"
+echo "  docker compose up -d vc-lodestar"

--- a/scripts/edit/lodestar/replace_operator.sh
+++ b/scripts/edit/lodestar/replace_operator.sh
@@ -1,0 +1,322 @@
+#!/usr/bin/env bash
+
+# Script to orchestrate the replace-operator ceremony for Charon distributed validators.
+#
+# This script guides node operators through the complete replace-operator workflow:
+# - For continuing operators: export ASDB → ceremony → update ASDB → import
+# - For new operators: ceremony only (no ASDB operations)
+#
+# Usage: replace_operator.sh [OPTIONS]
+#
+# Required Options (or will be prompted):
+#   --role <continuing|new>        Your role in the cluster (continuing or new operator)
+#   --old-enr <enr>                ENR of the operator being replaced
+#   --new-enr <enr>                ENR of the new operator
+#
+# Optional for new operators:
+#   --cluster-lock-file <path>     Path to cluster-lock.json (required for new operators)
+#
+# Optional directories:
+#   --output-dir <path>            Output directory for new cluster config (default: ./output)
+#   --backup-file <path>           Backup zip filename (default: .charon-before-replace-operator-TIMESTAMP.zip)
+#   --asdb-dir <path>              Directory for ASDB export/import (default: ./asdb-export)
+#
+# Requirements:
+#   - .charon/ directory must exist
+#   - Output directory must NOT exist
+#   - docker and docker compose must be available
+#   - zip command must be available
+
+set -euo pipefail
+
+# Default values
+ROLE=""
+OLD_ENR=""
+NEW_ENR=""
+CLUSTER_LOCK_FILE=""
+OUTPUT_DIR="./output"
+BACKUP_FILE=".charon-before-replace-operator-$(date +%Y%m%d-%H%M%S).zip"
+ASDB_DIR="./asdb-export"
+
+# Parse arguments
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --role)
+            ROLE="$2"
+            shift 2
+            ;;
+        --old-enr)
+            OLD_ENR="$2"
+            shift 2
+            ;;
+        --new-enr)
+            NEW_ENR="$2"
+            shift 2
+            ;;
+        --cluster-lock-file)
+            CLUSTER_LOCK_FILE="$2"
+            shift 2
+            ;;
+        --output-dir)
+            OUTPUT_DIR="$2"
+            shift 2
+            ;;
+        --backup-file)
+            BACKUP_FILE="$2"
+            shift 2
+            ;;
+        --asdb-dir)
+            ASDB_DIR="$2"
+            shift 2
+            ;;
+        -h|--help)
+            grep "^#" "$0" | grep -v "#!/usr/bin/env" | sed 's/^# \?//'
+            exit 0
+            ;;
+        *)
+            echo "Error: Unknown argument '$1'" >&2
+            echo "Use --help for usage information" >&2
+            exit 1
+            ;;
+    esac
+done
+
+# Interactive prompts for missing required values
+if [ -z "$ROLE" ]; then
+    echo "What is your role in this cluster?"
+    echo "  1) continuing - I am an existing operator staying in the cluster"
+    echo "  2) new - I am the new operator joining the cluster"
+    read -p "Enter choice (1 or 2): " role_choice
+    case $role_choice in
+        1) ROLE="continuing" ;;
+        2) ROLE="new" ;;
+        *)
+            echo "Error: Invalid choice" >&2
+            exit 1
+            ;;
+    esac
+fi
+
+# Validate role
+if [[ "$ROLE" != "continuing" && "$ROLE" != "new" ]]; then
+    echo "Error: Role must be 'continuing' or 'new'" >&2
+    exit 1
+fi
+
+if [ -z "$OLD_ENR" ]; then
+    read -p "Enter the ENR of the operator being replaced: " OLD_ENR
+fi
+
+if [ -z "$NEW_ENR" ]; then
+    read -p "Enter the ENR of the new operator: " NEW_ENR
+fi
+
+# For new operators, require cluster-lock file
+if [[ "$ROLE" == "new" ]]; then
+    if [ -z "$CLUSTER_LOCK_FILE" ]; then
+        read -p "Enter path to your cluster-lock.json file: " CLUSTER_LOCK_FILE
+    fi
+    
+    if [ ! -f "$CLUSTER_LOCK_FILE" ]; then
+        echo "Error: Cluster lock file not found: $CLUSTER_LOCK_FILE" >&2
+        exit 1
+    fi
+fi
+
+echo ""
+echo "============================================"
+echo "Charon Replace-Operator Ceremony"
+echo "============================================"
+echo "Role: $ROLE"
+echo "Old operator ENR: $OLD_ENR"
+echo "New operator ENR: $NEW_ENR"
+if [[ "$ROLE" == "new" ]]; then
+    echo "Cluster lock file: $CLUSTER_LOCK_FILE"
+fi
+echo "Output directory: $OUTPUT_DIR"
+echo "Backup file: $BACKUP_FILE"
+if [[ "$ROLE" == "continuing" ]]; then
+    echo "ASDB directory: $ASDB_DIR"
+fi
+echo "============================================"
+echo ""
+
+# Check prerequisites
+if [ ! -d .charon ]; then
+    echo "Error: .charon directory not found" >&2
+    echo "Please ensure you are running this script from the repository root" >&2
+    exit 1
+fi
+
+# Check if output directory already exists
+if [ -d "$OUTPUT_DIR" ]; then
+    echo "Error: Output directory already exists: $OUTPUT_DIR" >&2
+    echo "Please remove it before running the ceremony:" >&2
+    echo "  rm -rf $OUTPUT_DIR" >&2
+    echo "" >&2
+    echo "If you are retrying after a failed ceremony, ensure the output" >&2
+    echo "directory from the previous attempt is cleaned up." >&2
+    exit 1
+fi
+
+# Check if zip command is available
+if ! command -v zip &> /dev/null; then
+    echo "Error: 'zip' command not found" >&2
+    echo "Please install zip to create backups" >&2
+    exit 1
+fi
+
+# Step 1: Create backup
+echo "Step 1: Creating backup of .charon directory"
+echo ""
+read -p "Press Enter to create backup at $BACKUP_FILE (or Ctrl+C to abort)..."
+
+if ! zip -r "$BACKUP_FILE" .charon > /dev/null; then
+    echo "Error: Failed to create backup" >&2
+    exit 1
+fi
+
+echo "✓ Backup created: $BACKUP_FILE"
+echo ""
+
+# Step 2: For continuing operators, prompt to export ASDB
+if [[ "$ROLE" == "continuing" ]]; then
+    echo "Step 2: Export anti-slashing database"
+    echo ""
+    echo "Before proceeding with the ceremony, you must export your"
+    echo "anti-slashing database. Run the following command:"
+    echo ""
+    echo "  ./scripts/edit/lodestar/export_asdb.sh"
+    echo ""
+    read -p "Have you successfully exported the ASDB? (yes/no): " asdb_exported
+    
+    if [[ "$asdb_exported" != "yes" ]]; then
+        echo "Please export the ASDB before continuing" >&2
+        exit 1
+    fi
+    
+    echo "✓ ASDB export confirmed"
+    echo ""
+fi
+
+# Step 3: Execute ceremony
+echo "Step 3: Execute replace-operator ceremony"
+echo ""
+echo "This will run the Charon ceremony with all participating operators."
+echo "Ensure all operators are ready to execute this simultaneously."
+echo ""
+read -p "Press Enter to start the ceremony (or Ctrl+C to abort)..."
+
+
+echo "Running ceremony..."
+echo ""
+
+# Execute the ceremony using docker compose run with appropriate volume mounts
+# Using bash array for volumes to handle paths with spaces safely
+VOLUMES=(
+    -v "$(pwd)/.charon:/opt/charon/.charon"
+    -v "$(pwd)/output:/opt/charon/output"
+)
+
+if [[ "$ROLE" == "new" ]]; then
+    # For new operators, mount the cluster-lock file
+    if [[ "$CLUSTER_LOCK_FILE" == /* ]]; then
+        CLUSTER_LOCK_HOST_PATH="$CLUSTER_LOCK_FILE"
+    else
+        CLUSTER_LOCK_HOST_PATH="$(pwd)/$CLUSTER_LOCK_FILE"
+    fi
+    VOLUMES+=(-v "$CLUSTER_LOCK_HOST_PATH:/opt/charon/cluster-lock.json")
+fi
+
+if ! docker compose run --rm "${VOLUMES[@]}" charon alpha edit replace-operator \
+    --old-operator-enr="$OLD_ENR" \
+    --new-operator-enr="$NEW_ENR" \
+    --output-dir=/opt/charon/output \
+    $(if [[ "$ROLE" == "new" ]]; then echo "--lock-file=/opt/charon/cluster-lock.json --private-key-file=/opt/charon/charon-enr-private-key"; fi); then
+    echo "" >&2
+    echo "Error: Ceremony failed" >&2
+    echo "" >&2
+    echo "To rollback, restore your backup:" >&2
+    echo "  rm -rf .charon && unzip $BACKUP_FILE" >&2
+    exit 1
+fi
+
+echo ""
+echo "✓ Ceremony completed successfully"
+echo ""
+
+# Step 4: For continuing operators, update ASDB
+if [[ "$ROLE" == "continuing" ]]; then
+    echo "Step 4: Update anti-slashing database"
+    echo ""
+    echo "Translating validator keys in the exported ASDB..."
+    
+    ASDB_FILE="$ASDB_DIR/slashing-protection.json"
+    SOURCE_LOCK=".charon/cluster-lock.json"
+    TARGET_LOCK="$OUTPUT_DIR/cluster-lock.json"
+    
+    if ! ./scripts/edit/lib/update-anti-slashing-db.sh "$ASDB_FILE" "$SOURCE_LOCK" "$TARGET_LOCK"; then
+        echo "" >&2
+        echo "Error: Failed to update ASDB" >&2
+        echo "" >&2
+        echo "To rollback:" >&2
+        echo "  rm -rf .charon && unzip $BACKUP_FILE" >&2
+        echo "  rm -rf $OUTPUT_DIR" >&2
+        exit 1
+    fi
+    
+    echo ""
+    echo "✓ ASDB updated successfully"
+    echo ""
+fi
+
+# Step 5: Display final instructions
+echo "=========================================="
+echo "Ceremony Completed Successfully!"
+echo "=========================================="
+echo ""
+
+read -p "Press Enter to view the final steps..."
+
+echo ""
+echo "Next steps to activate the new cluster configuration:"
+echo ""
+echo "1. Stop services:"
+echo "   docker compose stop charon vc-lodestar"
+echo ""
+echo "2. Activate new configuration:"
+echo "   mv .charon .charon-old && mv $OUTPUT_DIR .charon"
+echo ""
+
+if [[ "$ROLE" == "continuing" ]]; then
+    echo "3. Import updated anti-slashing database:"
+    echo "   ./scripts/edit/lodestar/import_asdb.sh --input-file $ASDB_DIR/slashing-protection.json"
+    echo ""
+    echo "4. Coordinate with other operators:"
+fi
+
+if [[ "$ROLE" == "new" ]]; then
+    echo "3. Coordinate with other operators:"
+fi
+
+echo "   Confirm in your meeting that all operators have completed the above steps"
+echo ""
+
+if [[ "$ROLE" == "continuing" ]]; then
+    echo "5. Wait two epochs (approximately 13 minutes)"
+    echo ""
+    echo "6. Restart services together:"
+else
+    echo "4. Wait two epochs (approximately 13 minutes)"
+    echo ""
+    echo "5. Restart services together:"
+fi
+
+echo "   docker compose up -d charon vc-lodestar"
+echo ""
+echo "=========================================="
+echo ""
+echo "If anything goes wrong, rollback with:"
+echo "  rm -rf .charon"
+echo "  unzip $BACKUP_FILE"
+echo "=========================================="

--- a/scripts/update-anti-slashing-db.sh
+++ b/scripts/update-anti-slashing-db.sh
@@ -1,0 +1,206 @@
+#!/usr/bin/env bash
+
+# Script to update EIP-3076 anti-slashing DB by replacing pubkey values
+# based on lookup in source and target cluster-lock.json files.
+#
+# Usage: update-anti-slashing-db.sh <eip3076-file> <source-cluster-lock> <target-cluster-lock>
+#
+# Arguments:
+#   eip3076-file          - Path to EIP-3076 JSON file to update in place
+#   source-cluster-lock   - Path to source cluster-lock.json
+#   target-cluster-lock   - Path to target cluster-lock.json
+#
+# The script traverses the EIP-3076 JSON file and finds all "pubkey" values in the
+# data array. For each pubkey, it looks up the value in the source cluster-lock.json's
+# distributed_validators[].public_shares[] arrays, remembers the indices, and then
+# replaces the pubkey with the corresponding value from the target cluster-lock.json
+# at the same indices.
+
+set -euo pipefail
+
+# Check if jq is installed
+if ! command -v jq &> /dev/null; then
+    echo "Error: jq is required but not installed. Please install jq first." >&2
+    exit 1
+fi
+
+# Validate arguments
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <eip3076-file> <source-cluster-lock> <target-cluster-lock>" >&2
+    exit 1
+fi
+
+EIP3076_FILE="$1"
+SOURCE_LOCK="$2"
+TARGET_LOCK="$3"
+
+# Validate files exist
+if [ ! -f "$EIP3076_FILE" ]; then
+    echo "Error: EIP-3076 file not found: $EIP3076_FILE" >&2
+    exit 1
+fi
+
+if [ ! -f "$SOURCE_LOCK" ]; then
+    echo "Error: Source cluster-lock file not found: $SOURCE_LOCK" >&2
+    exit 1
+fi
+
+if [ ! -f "$TARGET_LOCK" ]; then
+    echo "Error: Target cluster-lock file not found: $TARGET_LOCK" >&2
+    exit 1
+fi
+
+# Create a temporary file for the updated EIP-3076 data
+TEMP_FILE=$(mktemp)
+trap 'rm -f "$TEMP_FILE"' EXIT
+
+# Function to find pubkey in cluster-lock and return validator_index,share_index
+# Returns empty string if not found
+find_pubkey_indices() {
+    local pubkey="$1"
+    local cluster_lock_file="$2"
+
+    # Search through distributed_validators and public_shares
+    jq -r --arg pubkey "$pubkey" '
+        .distributed_validators as $validators |
+        foreach range(0; $validators | length) as $v_idx (
+            null;
+            . ;
+            $validators[$v_idx].public_shares as $shares |
+            foreach range(0; $shares | length) as $s_idx (
+                null;
+                . ;
+                if $shares[$s_idx] == $pubkey then
+                    "\($v_idx),\($s_idx)"
+                else
+                    empty
+                end
+            )
+        ) | select(. != null)
+    ' "$cluster_lock_file" | head -n 1
+}
+
+# Function to get pubkey from cluster-lock at specific indices
+get_pubkey_at_indices() {
+    local validator_idx="$1"
+    local share_idx="$2"
+    local cluster_lock_file="$3"
+
+    jq -r --argjson v_idx "$validator_idx" --argjson s_idx "$share_idx" '
+        .distributed_validators[$v_idx].public_shares[$s_idx]
+    ' "$cluster_lock_file"
+}
+
+echo "Reading EIP-3076 file: $EIP3076_FILE"
+echo "Source cluster-lock: $SOURCE_LOCK"
+echo "Target cluster-lock: $TARGET_LOCK"
+echo ""
+
+# Validate cluster-lock structure
+source_validators=$(jq '.distributed_validators | length' "$SOURCE_LOCK")
+target_validators=$(jq '.distributed_validators | length' "$TARGET_LOCK")
+
+echo "Source cluster-lock has $source_validators validators"
+echo "Target cluster-lock has $target_validators validators"
+
+if [ "$source_validators" -eq 0 ]; then
+    echo "Error: Source cluster-lock has no validators" >&2
+    exit 1
+fi
+
+if [ "$target_validators" -eq 0 ]; then
+    echo "Error: Target cluster-lock has no validators" >&2
+    exit 1
+fi
+
+# Verify that target has at least as many validators as source
+if [ "$target_validators" -lt "$source_validators" ]; then
+    echo "Error: Target cluster-lock has fewer validators ($target_validators) than source ($source_validators)" >&2
+    echo "       This may result in missing pubkey replacements" >&2
+    exit 1
+fi
+
+echo ""
+
+# Read the EIP-3076 file
+eip3076_data=$(cat "$EIP3076_FILE")
+
+# Get all pubkeys from the data array
+pubkeys=$(echo "$eip3076_data" | jq -r '.data[].pubkey')
+
+if [ -z "$pubkeys" ]; then
+    echo "Warning: No pubkeys found in EIP-3076 file" >&2
+    exit 0
+fi
+
+# Start with the original data
+updated_data="$eip3076_data"
+
+# Process each pubkey
+while IFS= read -r old_pubkey; do
+    echo "Processing pubkey: $old_pubkey"
+
+    # Find indices in source cluster-lock
+    indices=$(find_pubkey_indices "$old_pubkey" "$SOURCE_LOCK")
+
+    if [ -z "$indices" ]; then
+        echo "  Error: Pubkey not found in source cluster-lock.json" >&2
+        echo "         Cannot proceed without mapping for all pubkeys" >&2
+        exit 1
+    fi
+
+    # Split indices
+    validator_idx=$(echo "$indices" | cut -d',' -f1)
+    share_idx=$(echo "$indices" | cut -d',' -f2)
+
+    echo "  Found at distributed_validators[$validator_idx].public_shares[$share_idx]"
+
+    # Verify target has sufficient validators
+    target_validator_count=$(jq '.distributed_validators | length' "$TARGET_LOCK")
+    if [ "$validator_idx" -ge "$target_validator_count" ]; then
+        echo "  Error: Target cluster-lock.json doesn't have validator at index $validator_idx" >&2
+        echo "         Target has only $target_validator_count validators" >&2
+        exit 1
+    fi
+
+    # Verify target validator has sufficient public_shares
+    target_share_count=$(jq --argjson v_idx "$validator_idx" '.distributed_validators[$v_idx].public_shares | length' "$TARGET_LOCK")
+    if [ "$share_idx" -ge "$target_share_count" ]; then
+        echo "  Error: Target cluster-lock.json validator[$validator_idx] doesn't have share at index $share_idx" >&2
+        echo "         Target validator has only $target_share_count shares" >&2
+        exit 1
+    fi
+
+    # Get corresponding pubkey from target cluster-lock
+    new_pubkey=$(get_pubkey_at_indices "$validator_idx" "$share_idx" "$TARGET_LOCK")
+
+    if [ -z "$new_pubkey" ] || [ "$new_pubkey" = "null" ]; then
+        echo "  Error: Could not find pubkey at same indices in target cluster-lock.json" >&2
+        exit 1
+    fi
+
+    echo "  Replacing with: $new_pubkey"
+
+    # Replace the pubkey in the JSON data
+    # We need to be careful to only replace the pubkey in the data array, not in other places
+    updated_data=$(echo "$updated_data" | jq --arg old "$old_pubkey" --arg new "$new_pubkey" '
+        (.data[] | select(.pubkey == $old) | .pubkey) |= $new
+    ')
+
+    echo "  Done"
+    echo ""
+done <<< "$pubkeys"
+
+# Write the updated data to temp file
+echo "$updated_data" | jq '.' > "$TEMP_FILE"
+
+# Validate the output is valid JSON
+if ! jq empty "$TEMP_FILE" 2>/dev/null; then
+    echo "Error: Generated invalid JSON" >&2
+    exit 1
+fi
+
+# Replace original file with updated version
+cp "$TEMP_FILE" "$EIP3076_FILE"
+
+echo "Successfully updated $EIP3076_FILE"


### PR DESCRIPTION
# Summary

Introduces a suite of automation scripts to streamline the charon alpha edit replace-operator workflow. This initial version supports the Lodestar validator client, handling the orchestration, anti-slashing database (ASDB) migration, and configuration swapping with built-in safety checks.

# Key Changes

Orchestration: Added [replace_operator.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to guide operators through the ceremony (supports both continuing & new operator roles).
ASDB Management: Added [export_asdb.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) and [import_asdb.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to handle Lodestar's slashing protection data using the EIP-3076 interchange format.
Library Refactor: Moved [update-anti-slashing-db.sh](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to [lib](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) to serve as a reusable utility for public key translation.
Documentation: Added [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) with detailed workflows, example sessions, and troubleshooting guides.

# Features
Interactive & CLI Modes: Scripts support full automation via flags or guided interactive prompts.
Safety: Automatically creates .charon backups before modifying state and prevents overwriting existing data.
Docker Integration: Uses ephemeral containers for the ceremony and proper entrypoint overrides for Lodestar management commands.

# Usage
See [README.md](vscode-file://vscode-app/Applications/Visual%20Studio%20Code.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html) for complete instructions.

```
# Run interactively
./scripts/edit/lodestar/replace_operator.sh

# Or via CLI flags
./scripts/edit/lodestar/replace_operator.sh --role continuing --old-enr ... --new-enr ...
```
