### PR TITLE
Add support for custom flags on validator clients

### DIFF
--- a/.env.sample.hoodi
+++ b/.env.sample.hoodi
@@ -85,6 +85,9 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://checkpoint-sync.hoodi.ethpandaops.io/
 # Override prometheus metrics port for validator client.
 #VC_PORT_METRICS=
 
+# Additional parameters for the validator client.
+#VC_EXTRAS=
+
 # Lodestar validator client docker container image version.
 # See available tags https://hub.docker.com/r/chainsafe/lodestar/tags
 #VC_LODESTAR_VERSION=

--- a/.env.sample.mainnet
+++ b/.env.sample.mainnet
@@ -85,6 +85,9 @@ LIGHTHOUSE_CHECKPOINT_SYNC_URL=https://mainnet.checkpoint.sigp.io/
 # Override prometheus metrics port for validator client.
 #VC_PORT_METRICS=
 
+# Additional parameters for the validator client.
+#VC_EXTRAS=
+
 # Lodestar validator client docker container image version.
 # See available tags https://hub.docker.com/r/chainsafe/lodestar/tags
 #VC_LODESTAR_VERSION=

--- a/compose-vc.yml
+++ b/compose-vc.yml
@@ -70,6 +70,7 @@ services:
     environment:
       BEACON_NODE_ADDRESS: http://charon:3600
       NETWORK: ${NETWORK}
+      VC_EXTRAS: ${VC_EXTRAS}
     labels:
       - "alloy-monitored=${VC_PRYSM_ALLOY_MONITORED:-true}"
     volumes:

--- a/compose-vc.yml
+++ b/compose-vc.yml
@@ -101,10 +101,9 @@ services:
       --validators-builder-registration-default-enabled ${BUILDER_API_ENABLED:-true}
       --validators-proposer-default-fee-recipient "0x0000000000000000000000000000000000000000"
       --Xobol-dvt-integration-enabled true
+      ${VC_EXTRAS:-}
     depends_on: [charon]
     networks: [dvnode]
-    environment:
-      VC_EXTRAS: ${VC_EXTRAS:-}
     labels:
       - "alloy-monitored=${VC_TEKU_ALLOY_MONITORED:-true}"
     volumes:

--- a/compose-vc.yml
+++ b/compose-vc.yml
@@ -70,7 +70,7 @@ services:
     environment:
       BEACON_NODE_ADDRESS: http://charon:3600
       NETWORK: ${NETWORK}
-      VC_EXTRAS: ${VC_EXTRAS}
+      VC_EXTRAS: ${VC_EXTRAS:-}
     labels:
       - "alloy-monitored=${VC_PRYSM_ALLOY_MONITORED:-true}"
     volumes:

--- a/compose-vc.yml
+++ b/compose-vc.yml
@@ -20,6 +20,7 @@ services:
       NETWORK: ${NETWORK}
       BUILDER_API_ENABLED: ${BUILDER_API_ENABLED:-true}
       BUILDER_SELECTION: ${VC_LODESTAR_BUILDER_SELECTION:-builderalways}
+      VC_EXTRAS: ${VC_EXTRAS:-}
     labels:
       - "alloy-monitored=${VC_LODESTAR_ALLOY_MONITORED:-true}"
     volumes:
@@ -46,6 +47,7 @@ services:
     environment:
       BEACON_NODE_ADDRESS: http://charon:3600
       BUILDER_API_ENABLED: ${BUILDER_API_ENABLED:-true}
+      VC_EXTRAS: ${VC_EXTRAS:-}
     labels:
       - "alloy-monitored=${VC_NIMBUS_ALLOY_MONITORED:-true}"
     volumes:
@@ -101,6 +103,8 @@ services:
       --Xobol-dvt-integration-enabled true
     depends_on: [charon]
     networks: [dvnode]
+    environment:
+      VC_EXTRAS: ${VC_EXTRAS:-}
     labels:
       - "alloy-monitored=${VC_TEKU_ALLOY_MONITORED:-true}"
     volumes:

--- a/lodestar/run.sh
+++ b/lodestar/run.sh
@@ -51,4 +51,5 @@ exec node /usr/app/packages/cli/bin/lodestar validator \
     --beaconNodes="$BEACON_NODE_ADDRESS" \
     --builder="$BUILDER_API_ENABLED" \
     --builder.selection="$BUILDER_SELECTION" \
-    --distributed
+    --distributed \
+    ${VC_EXTRAS:+$VC_EXTRAS}

--- a/nimbus/run.sh
+++ b/nimbus/run.sh
@@ -43,4 +43,5 @@ exec /home/user/nimbus_validator_client \
   --metrics \
   --metrics-address=0.0.0.0 \
   --payload-builder=${BUILDER_API_ENABLED} \
-  --distributed
+  --distributed \
+  ${VC_EXTRAS:+$VC_EXTRAS}

--- a/prysm/run.sh
+++ b/prysm/run.sh
@@ -50,4 +50,5 @@ echo "Imported all keys"
     --beacon-rest-api-provider="${BEACON_NODE_ADDRESS}" \
     --beacon-rpc-provider="${BEACON_NODE_ADDRESS}" \
     --"${NETWORK}" \
-    --distributed
+    --distributed \
+    ${VC_EXTRAS:+$VC_EXTRAS}


### PR DESCRIPTION
Added support for user to specify their own flags in .env to be passed to the validator client

This is consistent with the same feature in eth-docker

One use case for this is to be able to pass in the flag for a proposer config file with the file path, so that you can specify a per validator fee address