### PR TITLE
fix: enforce semantic commits in Renovate config

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": ["config:recommended"],
+  "semanticCommits": "enabled",
   "enabledManagers": ["github-actions", "regex"],
   "customManagers": [
     {


### PR DESCRIPTION
Renovate v43.104.0 changed its semantic commit auto-detector. Fix: explicitly set `"semanticCommits": "enabled"` instead of relying on auto-detection.