### PR TITLE
feat: add 2.relay.obol.dev + 3.relay.obol.dev to charon p2p relays

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -95,7 +95,7 @@ services:
       - CHARON_FALLBACK_BEACON_NODE_ENDPOINTS=${CHARON_FALLBACK_BEACON_NODE_ENDPOINTS:-}
       - CHARON_LOG_LEVEL=${CHARON_LOG_LEVEL:-info}
       - CHARON_LOG_FORMAT=${CHARON_LOG_FORMAT:-console}
-      - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech,https://1.relay.obol.tech/}
+      - CHARON_P2P_RELAYS=${CHARON_P2P_RELAYS:-https://0.relay.obol.tech,https://1.relay.obol.tech/,https://2.relay.obol.dev/,https://3.relay.obol.dev/}
       - CHARON_P2P_EXTERNAL_HOSTNAME=${CHARON_P2P_EXTERNAL_HOSTNAME:-} # Empty default required to avoid warnings.
       - CHARON_P2P_TCP_ADDRESS=0.0.0.0:${CHARON_PORT_P2P_TCP:-3610}
       - CHARON_VALIDATOR_API_ADDRESS=0.0.0.0:3600


### PR DESCRIPTION
## Summary

Obol stood up two new charon P2P relays (`2.relay.obol.dev` and `3.relay.obol.dev`). They've already been added to the nodeopco fleet config (see `obol-infrastructure` `nodeopco/ansible/playbooks/group_vars/all.yml`) but were missing from the CDVN docker-compose default — every operator running the stock stack only connected to `0+1.relay.obol.tech`.

## Changes

`docker-compose.yml`:
- `CHARON_P2P_RELAYS` default now lists all 4 relays:
  - `0.relay.obol.tech`
  - `1.relay.obol.tech`
  - `2.relay.obol.dev` (new)
  - `3.relay.obol.dev` (new)

`.env.sample.mainnet/hoodi` untouched — the `#CHARON_P2P_RELAYS=` line there is for users who want to override the defaults with a custom list, not the default itself.

## Test plan

- [ ] `docker compose config | grep CHARON_P2P_RELAYS` shows all 4 relays
- [ ] Restart charon container, confirm peer discovery picks up new relays in logs